### PR TITLE
docs: update license references from GPLv3 to AGPLv3

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -83,7 +83,7 @@ ChronDB is a chronological key/value database implemented in Clojure and backed 
 ### Dependencies
 
 - Manage dependencies via `deps.edn`
-- Verify compatibility with GPLv3 license requirements
+- Verify compatibility with AGPLv3 license requirements
 - Avoid adding dependencies that conflict with GraalVM native image constraints
 - Document new libraries and rationale in PR descriptions
 

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Please make sure to update tests as appropriate.
 
 ## 📄 License
 
-ChronDB is licensed under the terms of the GNU General Public License v3.0 (GPLv3).
+ChronDB is licensed under the terms of the GNU Affero General Public License v3.0 (AGPLv3).
 
 This means:
 
 - You are free to use, study, modify, and redistribute the software.
-- Any distributed modified version must also be licensed under GPLv3.
-- See the [LICENSE](./LICENSE) file for full details or visit [gnu.org/licenses/gpl-3.0](https://www.gnu.org/licenses/gpl-3.0.html).
+- If you run a modified version as a network service, you must make the source available to users of that service.
+- See the [LICENSE](./LICENSE) file for full details or visit [gnu.org/licenses/agpl-3.0](https://www.gnu.org/licenses/agpl-3.0.html).

--- a/dev/chrondb/build.clj
+++ b/dev/chrondb/build.clj
@@ -43,8 +43,8 @@
                 [:url "https://github.com/moclojer/chrondb"]
                 [:licenses
                  [:license
-                  [:name "GNU GPLv3"]
-                  [:url "https://www.gnu.org/licenses/gpl-3.0.en.html"]]]
+                  [:name "GNU AGPLv3"]
+                  [:url "https://www.gnu.org/licenses/agpl-3.0.en.html"]]]
                 [:scm
                  [:url "https://github.com/moclojer/chrondb"]
                  [:connection "scm:git:https://github.com/moclojer/chrondb.git"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@
 
 ChronDB is a chronological database built on Git's powerful architecture that gives your data complete version history. Think of it as "Git for your database" - every change is tracked, every version is accessible, and you can time-travel through your data's complete history.
 
+ChronDB is licensed under the GNU Affero General Public License v3.0 (AGPLv3), ensuring improvements deployed as hosted services remain available to the community.
+
 ## Why Choose ChronDB?
 
 - **Complete History** - Never lose data again. Every change is preserved in your database's timeline.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -34,3 +34,7 @@ This is the first official release of ChronDB, a chronological key/value databas
 ## Note
 
 This release represents the collaborative effort of the community to create a robust and efficient chronological key/value database. We thank all contributors who made this version possible.
+
+### Licensing Update
+
+- ChronDB is now distributed under the GNU Affero General Public License v3.0 (AGPLv3) to ensure modifications deployed as network services remain available to the community.

--- a/src/chrondb/core.clj
+++ b/src/chrondb/core.clj
@@ -1,16 +1,16 @@
 ;; This file is part of ChronDB.
 ;;
 ;; ChronDB is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published
+;; it under the terms of the GNU Affero General Public License as published
 ;; by the Free Software Foundation, either version 3 of the License,
 ;; or (at your option) any later version.
 ;;
 ;; ChronDB is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
+;; GNU Affero General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
+;; You should have received a copy of the GNU Affero General Public License
 ;; along with this program. If not, see <https://www.gnu.org/licenses/>.
 (ns chrondb.core
   "Core namespace for ChronDB - A chronological database with Git-like versioning"

--- a/src/chrondb/storage/git/commit.clj
+++ b/src/chrondb/storage/git/commit.clj
@@ -1,16 +1,16 @@
 ;; This file is part of ChronDB.
 ;;
 ;; ChronDB is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published
+;; it under the terms of the GNU Affero General Public License as published
 ;; by the Free Software Foundation, either version 3 of the License,
 ;; or (at your option) any later version.
 ;;
 ;; ChronDB is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
+;; GNU Affero General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
+;; You should have received a copy of the GNU Affero General Public License
 ;; along with this program. If not, see <https://www.gnu.org/licenses/>.
 (ns chrondb.storage.git.commit
   "Git commit operations for ChronDB storage"

--- a/src/chrondb/storage/git/core.clj
+++ b/src/chrondb/storage/git/core.clj
@@ -1,16 +1,16 @@
 ;; This file is part of ChronDB.
 ;;
 ;; ChronDB is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published
+;; it under the terms of the GNU Affero General Public License as published
 ;; by the Free Software Foundation, either version 3 of the License,
 ;; or (at your option) any later version.
 ;;
 ;; ChronDB is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
+;; GNU Affero General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
+;; You should have received a copy of the GNU Affero General Public License
 ;; along with this program. If not, see <https://www.gnu.org/licenses/>.
 (ns chrondb.storage.git.core
   "Core Git storage implementation for ChronDB"

--- a/src/chrondb/storage/git/document.clj
+++ b/src/chrondb/storage/git/document.clj
@@ -1,16 +1,16 @@
 ;; This file is part of ChronDB.
  ;;
- ;; ChronDB is free software: you can redistribute it and/or modify
- ;; it under the terms of the GNU General Public License as published
- ;; by the Free Software Foundation, either version 3 of the License,
- ;; or (at your option) any later version.
+;; ChronDB is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
  ;;
  ;; ChronDB is distributed in the hope that it will be useful,
  ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
  ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- ;; GNU General Public License for more details.
+;; GNU Affero General Public License for more details.
  ;;
- ;; You should have received a copy of the GNU General Public License
+;; You should have received a copy of the GNU Affero General Public License
  ;; along with this program. If not, see <https://www.gnu.org/licenses/>.
  (ns chrondb.storage.git.document
    "Document storage and retrieval operations for Git-based storage"

--- a/src/chrondb/storage/git/history.clj
+++ b/src/chrondb/storage/git/history.clj
@@ -1,16 +1,16 @@
 ;; This file is part of ChronDB.
  ;;
  ;; ChronDB is free software: you can redistribute it and/or modify
- ;; it under the terms of the GNU General Public License as published
+ ;; it under the terms of the GNU Affero General Public License as published
  ;; by the Free Software Foundation, either version 3 of the License,
  ;; or (at your option) any later version.
  ;;
  ;; ChronDB is distributed in the hope that it will be useful,
  ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
  ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- ;; GNU General Public License for more details.
+ ;; GNU Affero General Public License for more details.
  ;;
- ;; You should have received a copy of the GNU General Public License
+ ;; You should have received a copy of the GNU Affero General Public License
  ;; along with this program. If not, see <https://www.gnu.org/licenses/>.
  (ns chrondb.storage.git.history
    "Document history operations for Git-based storage"

--- a/src/chrondb/storage/git/path.clj
+++ b/src/chrondb/storage/git/path.clj
@@ -1,16 +1,16 @@
 ;; This file is part of ChronDB.
 ;;
 ;; ChronDB is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published
+;; it under the terms of the GNU Affero General Public License as published
 ;; by the Free Software Foundation, either version 3 of the License,
 ;; or (at your option) any later version.
 ;;
 ;; ChronDB is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
+;; GNU Affero General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
+;; You should have received a copy of the GNU Affero General Public License
 ;; along with this program. If not, see <https://www.gnu.org/licenses/>.
 (ns chrondb.storage.git.path
   "Path handling utilities for Git storage implementation"


### PR DESCRIPTION
- Updated all documentation and project files to consistently reference the GNU Affero General Public License v3.0 (AGPLv3) instead of GPLv3.
- Clarified licensing language in AGENT.md and README.md to reflect AGPLv3 compliance and obligations.
- Ensured that development guidelines and dependency management sections specify AGPLv3 compatibility requirements.
- This change aligns the project documentation with the actual software license used and helps ensure users and contributors are aware of the correct license terms.

fixed: #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated references to AGPLv3 across docs and README, including a new notice about network-use source availability and refreshed license links.
  - Added a Licensing Update section to the upcoming release notes.

- Chores
  - Standardized project licensing to AGPLv3 across headers and build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->