### PR TITLE
Optimize GitHub Actions to reduce macOS runner usage

### DIFF
--- a/.github/workflows/build-native-image.yml
+++ b/.github/workflows/build-native-image.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Build native image on ${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["macos-13", "ubuntu-22.04"]
+        os: ["macos-14", "ubuntu-22.04"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-shared-library.yml
+++ b/.github/workflows/build-shared-library.yml
@@ -3,7 +3,6 @@ name: Build Shared Library
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - "java/**"
       - "src/chrondb/lib/**"


### PR DESCRIPTION
Both build-shared-library.yml and release-shared-library.yml were running on push to main, executing the same build job twice and wasting limited macOS runner resources

Removed push trigger from build-shared-library.yml so it only runs on PRs (for validation) and manual dispatch. Release workflow already handles main branch builds. Also updated macos-13 to macos-14 in build-native-image.yml since 13 is deprecated