### PR TITLE
Expose remote repository operations through FFI bindings

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -97,6 +97,16 @@ char* chrondb_history(thread, handle, id, branch)            // → JSON array
 // Query
 char* chrondb_query(thread, handle, query_json, branch)      // → JSON result
 
+// SQL
+char* chrondb_execute_sql(thread, handle, sql, branch)       // → JSON result
+
+// Remote Operations
+char* chrondb_setup_remote(thread, handle, remote_url)       // → JSON {"type":"ok",...}
+char* chrondb_push(thread, handle)                           // → JSON {"type":"ok","status":"pushed|skipped|deferred"}
+char* chrondb_pull(thread, handle)                           // → JSON {"type":"ok","status":"pulled|current|skipped|conflict"}
+char* chrondb_fetch(thread, handle)                          // → JSON {"type":"ok","status":"fetched|skipped"}
+char* chrondb_remote_status(thread, handle)                  // → JSON {"type":"ok","configured":true|false}
+
 // Utilities
 void  chrondb_free_string(thread, ptr)   // free returned strings
 char* chrondb_last_error(thread)         // last error for this thread

--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -110,6 +110,32 @@ type ChrondbFreeStringFn =
 
 type ChrondbLastErrorFn = unsafe extern "C" fn(thread: *mut graal_isolatethread_t) -> *mut c_char;
 
+type ChrondbSetupRemoteFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+    remote_url: *const c_char,
+) -> *mut c_char;
+
+type ChrondbPushFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+) -> *mut c_char;
+
+type ChrondbPullFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+) -> *mut c_char;
+
+type ChrondbFetchFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+) -> *mut c_char;
+
+type ChrondbRemoteStatusFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+) -> *mut c_char;
+
 /// Holds the dynamically loaded library and function pointers.
 pub struct ChronDBLib {
     #[allow(dead_code)]
@@ -129,6 +155,11 @@ pub struct ChronDBLib {
     pub chrondb_open_path: ChrondbOpenPathFn,
     pub chrondb_free_string: ChrondbFreeStringFn,
     pub chrondb_last_error: ChrondbLastErrorFn,
+    pub chrondb_setup_remote: ChrondbSetupRemoteFn,
+    pub chrondb_push: ChrondbPushFn,
+    pub chrondb_pull: ChrondbPullFn,
+    pub chrondb_fetch: ChrondbFetchFn,
+    pub chrondb_remote_status: ChrondbRemoteStatusFn,
 }
 
 // Safety: The library handle and function pointers are safe to share across threads
@@ -253,6 +284,26 @@ impl ChronDBLib {
                 .get::<ChrondbLastErrorFn>(b"chrondb_last_error")
                 .map_err(|e| format!("Symbol chrondb_last_error not found: {}", e))?;
 
+            let chrondb_setup_remote: ChrondbSetupRemoteFn = *lib
+                .get::<ChrondbSetupRemoteFn>(b"chrondb_setup_remote")
+                .map_err(|e| format!("Symbol chrondb_setup_remote not found: {}", e))?;
+
+            let chrondb_push: ChrondbPushFn = *lib
+                .get::<ChrondbPushFn>(b"chrondb_push")
+                .map_err(|e| format!("Symbol chrondb_push not found: {}", e))?;
+
+            let chrondb_pull: ChrondbPullFn = *lib
+                .get::<ChrondbPullFn>(b"chrondb_pull")
+                .map_err(|e| format!("Symbol chrondb_pull not found: {}", e))?;
+
+            let chrondb_fetch: ChrondbFetchFn = *lib
+                .get::<ChrondbFetchFn>(b"chrondb_fetch")
+                .map_err(|e| format!("Symbol chrondb_fetch not found: {}", e))?;
+
+            let chrondb_remote_status: ChrondbRemoteStatusFn = *lib
+                .get::<ChrondbRemoteStatusFn>(b"chrondb_remote_status")
+                .map_err(|e| format!("Symbol chrondb_remote_status not found: {}", e))?;
+
             Ok(ChronDBLib {
                 lib,
                 graal_create_isolate,
@@ -270,6 +321,11 @@ impl ChronDBLib {
                 chrondb_open_path,
                 chrondb_free_string,
                 chrondb_last_error,
+                chrondb_setup_remote,
+                chrondb_push,
+                chrondb_pull,
+                chrondb_fetch,
+                chrondb_remote_status,
             })
         }
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -102,6 +102,22 @@ enum FfiCommand {
     LastError {
         reply: Sender<Option<String>>,
     },
+    SetupRemote {
+        remote_url: String,
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    Push {
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    Pull {
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    Fetch {
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    RemoteStatus {
+        reply: Sender<Result<serde_json::Value>>,
+    },
     Shutdown,
 }
 
@@ -327,6 +343,60 @@ impl FfiWorkerState {
 
         if result.is_null() {
             return Err(self.last_error_or("execute_sql failed"));
+        }
+        self.parse_string_result(result)
+    }
+
+    fn handle_setup_remote(&self, remote_url: &str) -> Result<serde_json::Value> {
+        let c_url =
+            CString::new(remote_url).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+
+        let result = unsafe {
+            (self.lib.chrondb_setup_remote)(
+                self.thread,
+                self.handle,
+                c_url.as_ptr() as *mut c_char,
+            )
+        };
+
+        if result.is_null() {
+            return Err(self.last_error_or("setup_remote failed"));
+        }
+        self.parse_string_result(result)
+    }
+
+    fn handle_push(&self) -> Result<serde_json::Value> {
+        let result = unsafe { (self.lib.chrondb_push)(self.thread, self.handle) };
+
+        if result.is_null() {
+            return Err(self.last_error_or("push failed"));
+        }
+        self.parse_string_result(result)
+    }
+
+    fn handle_pull(&self) -> Result<serde_json::Value> {
+        let result = unsafe { (self.lib.chrondb_pull)(self.thread, self.handle) };
+
+        if result.is_null() {
+            return Err(self.last_error_or("pull failed"));
+        }
+        self.parse_string_result(result)
+    }
+
+    fn handle_fetch(&self) -> Result<serde_json::Value> {
+        let result = unsafe { (self.lib.chrondb_fetch)(self.thread, self.handle) };
+
+        if result.is_null() {
+            return Err(self.last_error_or("fetch failed"));
+        }
+        self.parse_string_result(result)
+    }
+
+    fn handle_remote_status(&self) -> Result<serde_json::Value> {
+        let result = unsafe { (self.lib.chrondb_remote_status)(self.thread, self.handle) };
+
+        if result.is_null() {
+            return Err(self.last_error_or("remote_status failed"));
         }
         self.parse_string_result(result)
     }
@@ -664,6 +734,26 @@ impl ChronDB {
             FfiCommand::LastError { reply } => {
                 let _ = reply.send(state.get_last_error());
             }
+            FfiCommand::SetupRemote { remote_url, reply } => {
+                let result = state.handle_setup_remote(&remote_url);
+                let _ = reply.send(result);
+            }
+            FfiCommand::Push { reply } => {
+                let result = state.handle_push();
+                let _ = reply.send(result);
+            }
+            FfiCommand::Pull { reply } => {
+                let result = state.handle_pull();
+                let _ = reply.send(result);
+            }
+            FfiCommand::Fetch { reply } => {
+                let result = state.handle_fetch();
+                let _ = reply.send(result);
+            }
+            FfiCommand::RemoteStatus { reply } => {
+                let result = state.handle_remote_status();
+                let _ = reply.send(result);
+            }
             FfiCommand::Shutdown => return true,
         }
         false
@@ -763,6 +853,11 @@ impl ChronDB {
             FfiCommand::Query { reply, .. } => { let _ = reply.send(Err(err)); }
             FfiCommand::ExecuteSql { reply, .. } => { let _ = reply.send(Err(err)); }
             FfiCommand::LastError { reply, .. } => { let _ = reply.send(None); }
+            FfiCommand::SetupRemote { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::Push { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::Pull { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::Fetch { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::RemoteStatus { reply, .. } => { let _ = reply.send(Err(err)); }
             FfiCommand::Shutdown => {}
         }
     }
@@ -941,6 +1036,91 @@ impl ChronDB {
     /// Convenience alias for [`execute_sql`](Self::execute_sql).
     pub fn execute(&self, sql: &str, branch: Option<&str>) -> Result<serde_json::Value> {
         self.execute_sql(sql, branch)
+    }
+
+    /// Configures a remote repository URL for syncing.
+    ///
+    /// # Arguments
+    /// * `remote_url` - The remote Git URL (e.g., "git@github.com:org/repo.git")
+    pub fn setup_remote(&self, remote_url: &str) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        self.shared
+            .sender
+            .send(FfiCommand::SetupRemote {
+                remote_url: remote_url.to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+
+        reply_rx
+            .recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Pushes local changes to the configured remote repository.
+    ///
+    /// Returns a JSON value with `{"type":"ok","status":"pushed"|"skipped"|"deferred"}`.
+    pub fn push(&self) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        self.shared
+            .sender
+            .send(FfiCommand::Push { reply: reply_tx })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+
+        reply_rx
+            .recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Pulls changes from the configured remote repository.
+    ///
+    /// Fetches and fast-forwards the local branch.
+    /// Returns a JSON value with `{"type":"ok","status":"pulled"|"current"|"skipped"|"conflict"}`.
+    pub fn pull(&self) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        self.shared
+            .sender
+            .send(FfiCommand::Pull { reply: reply_tx })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+
+        reply_rx
+            .recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Fetches changes from the configured remote without merging.
+    ///
+    /// Returns a JSON value with `{"type":"ok","status":"fetched"|"skipped"}`.
+    pub fn fetch(&self) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        self.shared
+            .sender
+            .send(FfiCommand::Fetch { reply: reply_tx })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+
+        reply_rx
+            .recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Returns the remote configuration status.
+    ///
+    /// Returns a JSON value with `{"type":"ok","configured":true|false}`.
+    pub fn remote_status(&self) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        self.shared
+            .sender
+            .send(FfiCommand::RemoteStatus { reply: reply_tx })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+
+        reply_rx
+            .recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
     }
 
     /// Returns the last error message from the native library, if any.

--- a/bindings/uniffi/src/chrondb.udl
+++ b/bindings/uniffi/src/chrondb.udl
@@ -45,5 +45,20 @@ interface ChronDB {
     [Throws=ChronDBError]
     string execute_sql(string sql, string? branch);
 
+    [Throws=ChronDBError]
+    string setup_remote(string remote_url);
+
+    [Throws=ChronDBError]
+    string push();
+
+    [Throws=ChronDBError]
+    string pull();
+
+    [Throws=ChronDBError]
+    string fetch();
+
+    [Throws=ChronDBError]
+    string remote_status();
+
     string? last_error();
 };

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -145,6 +145,41 @@ impl ChronDB {
         Ok(result.to_string())
     }
 
+    fn setup_remote(&self, remote_url: String) -> Result<String, ChronDBError> {
+        let result = self.inner.setup_remote(&remote_url)?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn push(&self) -> Result<String, ChronDBError> {
+        let result = self.inner.push()?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn pull(&self) -> Result<String, ChronDBError> {
+        let result = self.inner.pull()?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn fetch(&self) -> Result<String, ChronDBError> {
+        let result = self.inner.fetch()?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn remote_status(&self) -> Result<String, ChronDBError> {
+        let result = self.inner.remote_status()?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
     fn last_error(&self) -> Option<String> {
         self.inner.last_error()
     }

--- a/docs/bindings/python.md
+++ b/docs/bindings/python.md
@@ -198,6 +198,60 @@ Executes a SQL query directly against the database without needing a running ser
 
 ---
 
+### `setup_remote(remote_url) -> Dict[str, Any]`
+
+Configures a remote Git repository URL for syncing.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `remote_url` | `str` | Remote Git URL (e.g., `"git@github.com:org/repo.git"`) |
+
+**Returns:** `{"type": "ok", "remote_url": "..."}` on success.
+
+**Raises:** `ChronDBError` on failure.
+
+---
+
+### `push() -> Dict[str, Any]`
+
+Pushes local changes to the configured remote repository.
+
+**Returns:** `{"type": "ok", "status": "pushed"}` on success, `{"type": "ok", "status": "skipped"}` if no remote is configured.
+
+**Raises:** `ChronDBError` on failure.
+
+---
+
+### `pull() -> Dict[str, Any]`
+
+Pulls changes from the configured remote repository. Fetches and fast-forwards the local branch.
+
+**Returns:** `{"type": "ok", "status": "pulled|current|skipped|conflict"}`.
+
+**Raises:** `ChronDBError` on failure.
+
+---
+
+### `fetch() -> Dict[str, Any]`
+
+Fetches changes from the configured remote without merging.
+
+**Returns:** `{"type": "ok", "status": "fetched|skipped"}`.
+
+**Raises:** `ChronDBError` on failure.
+
+---
+
+### `remote_status() -> Dict[str, Any]`
+
+Returns whether a remote repository is configured.
+
+**Returns:** `{"type": "ok", "configured": true|false}`.
+
+**Raises:** `ChronDBError` on failure.
+
+---
+
 ### `close()`
 
 Closes the database connection and releases native resources. Called automatically when using the context manager.
@@ -317,6 +371,29 @@ with ChronDB("./mydb") as db:
 
     result = db.execute("SELECT * FROM user WHERE name = 'Alice'")
     print(result["rows"])     # [{"name": "Alice", "age": 30}]
+```
+
+### Remote Sync
+
+```python
+with ChronDB("./mydb") as db:
+    # Configure remote
+    db.setup_remote("git@github.com:org/data.git")
+
+    # Write data locally
+    db.put("user:1", {"name": "Alice"})
+
+    # Push to remote
+    result = db.push()
+    print(result["status"])  # "pushed"
+
+    # Pull latest from remote
+    result = db.pull()
+    print(result["status"])  # "pulled" or "current"
+
+    # Check remote status
+    status = db.remote_status()
+    print(status["configured"])  # True
 ```
 
 ### Idle Timeout (long-running services)

--- a/docs/bindings/rust.md
+++ b/docs/bindings/rust.md
@@ -288,6 +288,60 @@ Executes a SQL query directly against the database without needing a running ser
 
 ---
 
+### `setup_remote(&self, remote_url) -> Result<serde_json::Value>`
+
+Configures a remote Git repository URL for syncing.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `remote_url` | `&str` | Remote Git URL (e.g., `"git@github.com:org/repo.git"`) |
+
+**Returns:** `{"type":"ok","remote_url":"..."}` on success.
+
+**Errors:** `OperationFailed(reason)`
+
+---
+
+### `push(&self) -> Result<serde_json::Value>`
+
+Pushes local changes to the configured remote repository.
+
+**Returns:** `{"type":"ok","status":"pushed"}` on success, `{"type":"ok","status":"skipped"}` if no remote is configured.
+
+**Errors:** `OperationFailed(reason)`
+
+---
+
+### `pull(&self) -> Result<serde_json::Value>`
+
+Pulls changes from the configured remote repository. Fetches and fast-forwards the local branch.
+
+**Returns:** `{"type":"ok","status":"pulled|current|skipped|conflict"}`.
+
+**Errors:** `OperationFailed(reason)`
+
+---
+
+### `fetch(&self) -> Result<serde_json::Value>`
+
+Fetches changes from the configured remote without merging.
+
+**Returns:** `{"type":"ok","status":"fetched|skipped"}`.
+
+**Errors:** `OperationFailed(reason)`
+
+---
+
+### `remote_status(&self) -> Result<serde_json::Value>`
+
+Returns whether a remote repository is configured.
+
+**Returns:** `{"type":"ok","configured":true|false}`.
+
+**Errors:** `OperationFailed(reason)`
+
+---
+
 ### `last_error(&self) -> Option<String>`
 
 Returns the last error message from the native library, if any.
@@ -455,6 +509,37 @@ fn main() -> chrondb::Result<()> {
 
     let result = db.execute_sql("SELECT * FROM user WHERE name = 'Alice'", None)?;
     println!("Rows: {}", result["rows"]);
+
+    Ok(())
+}
+```
+
+### Remote Sync
+
+```rust
+use chrondb::ChronDB;
+use serde_json::json;
+
+fn main() -> chrondb::Result<()> {
+    let db = ChronDB::open_path("./mydb")?;
+
+    // Configure remote
+    db.setup_remote("git@github.com:org/data.git")?;
+
+    // Write data locally
+    db.put("user:1", &json!({"name": "Alice"}), None)?;
+
+    // Push to remote
+    let result = db.push()?;
+    println!("Push: {}", result["status"]); // "pushed"
+
+    // Pull latest from remote
+    let result = db.pull()?;
+    println!("Pull: {}", result["status"]); // "pulled" or "current"
+
+    // Check remote status
+    let status = db.remote_status()?;
+    println!("Remote configured: {}", status["configured"]); // true
 
     Ok(())
 }

--- a/java/chrondb/lib/ChronDBLib.java
+++ b/java/chrondb/lib/ChronDBLib.java
@@ -32,6 +32,11 @@ public final class ChronDBLib {
     private static IFn libHistory;
     private static IFn libQuery;
     private static IFn libExecuteSql;
+    private static IFn libSetupRemote;
+    private static IFn libPush;
+    private static IFn libPull;
+    private static IFn libFetch;
+    private static IFn libRemoteStatus;
 
     private static synchronized void ensureInitialized() {
         if (!initialized) {
@@ -49,6 +54,11 @@ public final class ChronDBLib {
             libHistory = Clojure.var("chrondb.lib.core", "lib-history");
             libQuery = Clojure.var("chrondb.lib.core", "lib-query");
             libExecuteSql = Clojure.var("chrondb.lib.core", "lib-execute-sql");
+            libSetupRemote = Clojure.var("chrondb.lib.core", "lib-setup-remote");
+            libPush = Clojure.var("chrondb.lib.core", "lib-push");
+            libPull = Clojure.var("chrondb.lib.core", "lib-pull");
+            libFetch = Clojure.var("chrondb.lib.core", "lib-fetch");
+            libRemoteStatus = Clojure.var("chrondb.lib.core", "lib-remote-status");
 
             initialized = true;
         }
@@ -280,6 +290,89 @@ public final class ChronDBLib {
                 return toCString((String) result);
             }
             lastError = ("execute_sql returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    // --- Remote Operations ---
+
+    @CEntryPoint(name = "chrondb_setup_remote")
+    public static CCharPointer setupRemote(IsolateThread thread, int handle, CCharPointer remoteUrl) {
+        try {
+            ensureInitialized();
+            String url = toJavaString(remoteUrl);
+            Object result = libSetupRemote.invoke(handle, url);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("setup_remote returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_push")
+    public static CCharPointer push(IsolateThread thread, int handle) {
+        try {
+            ensureInitialized();
+            Object result = libPush.invoke(handle);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("push returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_pull")
+    public static CCharPointer pull(IsolateThread thread, int handle) {
+        try {
+            ensureInitialized();
+            Object result = libPull.invoke(handle);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("pull returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_fetch")
+    public static CCharPointer fetch(IsolateThread thread, int handle) {
+        try {
+            ensureInitialized();
+            Object result = libFetch.invoke(handle);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("fetch returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_remote_status")
+    public static CCharPointer remoteStatus(IsolateThread thread, int handle) {
+        try {
+            ensureInitialized();
+            Object result = libRemoteStatus.invoke(handle);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("remote_status returned null");
             return WordFactory.nullPointer();
         } catch (Exception e) {
             lastError = (e.getMessage());

--- a/src/chrondb/lib/core.clj
+++ b/src/chrondb/lib/core.clj
@@ -7,7 +7,9 @@
    - Each unique (data-path, index-path) pair is opened only once (singleton)
    - Multiple handles can reference the same storage/index instance
    - Operations are thread-safe via JGit's internal locking"
-  (:require [chrondb.storage.git.core :as git]
+  (:require [chrondb.config :as config]
+            [chrondb.storage.git.core :as git]
+            [chrondb.storage.git.remote :as remote]
             [chrondb.storage.protocol :as storage]
             [chrondb.index.lucene :as lucene]
             [chrondb.index.protocol :as index]
@@ -15,7 +17,8 @@
             [chrondb.util.locks :as locks]
             [clojure.data.json :as json]
             [clojure.java.io :as io])
-  (:import [java.util.concurrent.atomic AtomicInteger]))
+  (:import [java.util.concurrent.atomic AtomicInteger]
+           [org.eclipse.jgit.api Git]))
 
 (def ^:private default-index-subdir ".chrondb-index")
 
@@ -399,6 +402,97 @@
                      (assoc parsed :schema branch)
                      parsed)]
         (json/write-str (execute-sql-dispatch storage index parsed branch))))
+    (catch Throwable e
+      (json/write-str {:type "error"
+                       :message (.getMessage e)}))))
+
+(defn lib-setup-remote
+  "Configures a remote repository URL for the database.
+   Returns a JSON string with the result:
+   - Success: {\"type\":\"ok\",\"remote_url\":\"...\"}
+   - Error: {\"type\":\"error\",\"message\":\"...\"}
+   Returns nil if handle is invalid."
+  [handle remote-url]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [repo (:repository storage)
+            git (Git/wrap repo)]
+        (remote/setup-remote git {:git {:remote-url remote-url}})
+        (json/write-str {:type "ok" :remote_url remote-url})))
+    (catch Throwable e
+      (json/write-str {:type "error"
+                       :message (.getMessage e)}))))
+
+(defn lib-push
+  "Pushes local changes to the configured remote repository.
+   Returns a JSON string with the result:
+   - Success: {\"type\":\"ok\",\"status\":\"pushed\"}
+   - Skipped: {\"type\":\"ok\",\"status\":\"skipped\"}
+   - Error: {\"type\":\"error\",\"message\":\"...\"}
+   Returns nil if handle is invalid."
+  [handle]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [repo (:repository storage)
+            git (Git/wrap repo)
+            config-map (config/load-config)
+            result (remote/push-to-remote git config-map)]
+        (json/write-str {:type "ok" :status (name result)})))
+    (catch Throwable e
+      (json/write-str {:type "error"
+                       :message (.getMessage e)}))))
+
+(defn lib-pull
+  "Pulls changes from the configured remote repository.
+   Returns a JSON string with the result:
+   - Success: {\"type\":\"ok\",\"status\":\"pulled\"}
+   - Current: {\"type\":\"ok\",\"status\":\"current\"}
+   - Skipped: {\"type\":\"ok\",\"status\":\"skipped\"}
+   - Conflict: {\"type\":\"ok\",\"status\":\"conflict\"}
+   - Error: {\"type\":\"error\",\"message\":\"...\"}
+   Returns nil if handle is invalid."
+  [handle]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [repo (:repository storage)
+            git (Git/wrap repo)
+            config-map (config/load-config)
+            result (remote/pull-from-remote git config-map)]
+        (json/write-str {:type "ok" :status (name result)})))
+    (catch Throwable e
+      (json/write-str {:type "error"
+                       :message (.getMessage e)}))))
+
+(defn lib-fetch
+  "Fetches changes from the configured remote without merging.
+   Returns a JSON string with the result:
+   - Success: {\"type\":\"ok\",\"status\":\"fetched\"}
+   - Skipped: {\"type\":\"ok\",\"status\":\"skipped\"}
+   - Error: {\"type\":\"error\",\"message\":\"...\"}
+   Returns nil if handle is invalid."
+  [handle]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [repo (:repository storage)
+            git (Git/wrap repo)
+            config-map (config/load-config)
+            result (remote/fetch-from-remote git config-map)]
+        (json/write-str {:type "ok" :status (name result)})))
+    (catch Throwable e
+      (json/write-str {:type "error"
+                       :message (.getMessage e)}))))
+
+(defn lib-remote-status
+  "Returns the remote configuration status for the database.
+   Returns a JSON string:
+   - {\"type\":\"ok\",\"configured\":true/false}
+   Returns nil if handle is invalid."
+  [handle]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [repo (:repository storage)
+            configured? (remote/remote-configured? repo "origin")]
+        (json/write-str {:type "ok" :configured configured?})))
     (catch Throwable e
       (json/write-str {:type "error"
                        :message (.getMessage e)}))))

--- a/test/chrondb/lib/core_test.clj
+++ b/test/chrondb/lib/core_test.clj
@@ -279,3 +279,77 @@
             (is (some? doc2) "Document 2 should persist"))
           (finally
             (lib/lib-close handle3)))))))
+
+;; --- Remote Operations Tests ---
+
+(deftest test-lib-remote-status-no-remote
+  (testing "lib-remote-status should report no remote when none is configured"
+    (let [handle (lib/lib-open *test-data-dir* *test-index-dir*)]
+      (try
+        (is (>= handle 0) "handle should be valid")
+        (let [result (lib/lib-remote-status handle)]
+          (is (some? result) "remote-status should return a result")
+          (is (string? result) "result should be JSON string")
+          (is (.contains result "\"configured\":false")
+              "should report no remote configured"))
+        (finally
+          (lib/lib-close handle))))))
+
+(deftest test-lib-remote-status-invalid-handle
+  (testing "lib-remote-status with invalid handle should return nil"
+    (let [result (lib/lib-remote-status 99999)]
+      (is (nil? result) "invalid handle should return nil"))))
+
+(deftest test-lib-push-no-remote
+  (testing "lib-push without remote should return skipped status"
+    (let [handle (lib/lib-open *test-data-dir* *test-index-dir*)]
+      (try
+        (is (>= handle 0) "handle should be valid")
+        (let [result (lib/lib-push handle)]
+          (is (some? result) "push should return a result")
+          (is (.contains result "\"status\":\"skipped\"")
+              "push without remote should be skipped"))
+        (finally
+          (lib/lib-close handle))))))
+
+(deftest test-lib-pull-no-remote
+  (testing "lib-pull without remote should return skipped status"
+    (let [handle (lib/lib-open *test-data-dir* *test-index-dir*)]
+      (try
+        (is (>= handle 0) "handle should be valid")
+        (let [result (lib/lib-pull handle)]
+          (is (some? result) "pull should return a result")
+          (is (.contains result "\"status\":\"skipped\"")
+              "pull without remote should be skipped"))
+        (finally
+          (lib/lib-close handle))))))
+
+(deftest test-lib-fetch-no-remote
+  (testing "lib-fetch without remote should return skipped status"
+    (let [handle (lib/lib-open *test-data-dir* *test-index-dir*)]
+      (try
+        (is (>= handle 0) "handle should be valid")
+        (let [result (lib/lib-fetch handle)]
+          (is (some? result) "fetch should return a result")
+          (is (.contains result "\"status\":\"skipped\"")
+              "fetch without remote should be skipped"))
+        (finally
+          (lib/lib-close handle))))))
+
+(deftest test-lib-setup-remote
+  (testing "lib-setup-remote should configure a remote URL"
+    (let [handle (lib/lib-open *test-data-dir* *test-index-dir*)]
+      (try
+        (is (>= handle 0) "handle should be valid")
+        (let [result (lib/lib-setup-remote handle "https://github.com/test/repo.git")]
+          (is (some? result) "setup-remote should return a result")
+          (is (.contains result "\"type\":\"ok\"")
+              "setup-remote should return ok")
+          (is (.contains result "repo.git")
+              "result should contain the remote URL"))
+        ;; After setup, remote-status should report configured
+        (let [status (lib/lib-remote-status handle)]
+          (is (.contains status "\"configured\":true")
+              "remote should be configured after setup"))
+        (finally
+          (lib/lib-close handle))))))


### PR DESCRIPTION
The server already supports push/pull/fetch/clone via Git remotes, but none of that was accessible through the native library. Embedded users (Rust, Python) were stuck with local-only storage.

Added setup_remote, push, pull, fetch, and remote_status across all four layers: Clojure bridge, Java CEntryPoint, Rust SDK, and UniFFI. Each returns a JSON result with status so callers can react to skipped/conflict scenarios. Includes tests for the no-remote path and docs for both SDKs.

Closes #105