### PR TITLE
Add export-to-directory and expose backup/export via FFI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ ChronDB is a **chronological key/value database** implemented in Clojure, backed
 - **Multi-protocol**: REST API, Redis RESP protocol, PostgreSQL wire protocol
 - **Time-travel**: Query any point in history via commit selection
 - **Branching**: Isolated environments via Git branches
-- **FFI bindings**: Python and Rust clients via GraalVM native-image shared library
+- **FFI bindings**: Python, Rust, Node.js, and Ruby clients via GraalVM native-image shared library (UniFFI + NAPI-RS)
 
 ### Conceptual Mapping
 
@@ -98,30 +98,50 @@ chrondb/
 │   │   └── locks.clj         # Lock cleanup
 │   ├── tools/                # Developer tools
 │   │   ├── diagnose.clj      # Repository diagnostics
-│   │   ├── dump.clj          # Data export
+│   │   ├── dump.clj          # Data dump (stdout)
+│   │   ├── export.clj        # Bare repo → filesystem export
 │   │   └── migrator.clj      # Data migration
 │   └── lib/                  # FFI entry points
 │       └── core.clj          # Native library exports
-├── test/                     # Test suite (61 files)
+├── test/                     # Test suite
 │   └── chrondb/
 │       ├── storage/git/      # Storage integration tests
 │       ├── api/              # Protocol tests
 │       ├── transaction/      # Transaction tests
 │       ├── wal/              # WAL recovery tests
 │       ├── query/            # AST tests
+│       ├── backup/           # Backup/restore tests
+│       ├── index/            # Lucene index tests
+│       ├── lib/              # FFI bridge tests
+│       ├── tools/            # Export tool tests
+│       ├── validation/       # Schema validation tests
+│       ├── concurrency/      # OCC tests
+│       ├── temporal/         # Time-travel tests
 │       └── benchmark/        # Performance benchmarks
 ├── bindings/                 # Language bindings (FFI)
-│   ├── python/               # Python client (ctypes)
+│   ├── rust/                 # Rust core client (all others depend on this)
+│   │   ├── src/
+│   │   │   ├── lib.rs        # Safe wrapper + worker thread
+│   │   │   ├── ffi.rs        # Dynamic FFI symbol loading
+│   │   │   └── setup.rs      # Library auto-download
+│   │   └── Cargo.toml
+│   ├── uniffi/               # UniFFI bridge (generates Python/Ruby/Kotlin/Swift)
+│   │   ├── src/
+│   │   │   ├── chrondb.udl   # Interface definition
+│   │   │   └── lib.rs        # Rust implementation
+│   │   └── Cargo.toml
+│   ├── python/               # Python client (UniFFI-generated + wrapper)
 │   │   ├── chrondb/
-│   │   │   ├── client.py     # High-level API
-│   │   │   └── _ffi.py       # FFI loader
+│   │   │   ├── _wrapper.py   # High-level dict-based API
+│   │   │   └── _generated/   # UniFFI auto-generated
 │   │   └── tests/
-│   └── rust/                 # Rust client
-│       ├── src/
-│       │   ├── lib.rs        # Safe wrapper
-│       │   ├── ffi.rs        # FFI definitions
-│       │   └── setup.rs      # Library setup
-│       └── Cargo.toml
+│   ├── ruby/                 # Ruby client (UniFFI-generated + wrapper)
+│   │   ├── lib/chrondb.rb    # High-level API
+│   │   └── test/
+│   └── node/                 # Node.js client (NAPI-RS)
+│       ├── src/lib.rs        # NAPI-RS Rust implementation
+│       ├── index.js          # JS wrapper
+│       └── index.d.ts        # TypeScript definitions
 ├── dev/                      # Build tooling
 │   └── chrondb/
 │       ├── build.clj         # Uberjar builder
@@ -132,6 +152,8 @@ chrondb/
 ├── docs/                     # Documentation
 ├── deps.edn                  # Clojure dependencies
 ├── config.example.edn        # Configuration template
+├── docker-compose.yml        # Multi-service Docker setup
+├── CONTRIBUTING.md           # Contributor guidelines
 └── Dockerfile                # Multi-stage Docker build
 ```
 
@@ -202,12 +224,14 @@ All protocols share the same storage/index backend:
 
 ### FFI Bindings
 
-Both Python and Rust use a **shared isolate pattern** to avoid GraalVM file lock conflicts:
+All bindings (Python, Rust, Ruby, Node.js) use a **shared isolate pattern** to avoid GraalVM file lock conflicts:
 
 - Global registry keyed by `(data_path, index_path)`
 - Multiple instances → single isolate, thread-safe
 - Reference counting for cleanup
 - **64MB stack** for Rust FFI worker (Lucene/JGit deep call chains)
+- **UniFFI** generates Python, Ruby, Kotlin, Swift from a single UDL definition
+- **NAPI-RS** generates Node.js native module from Rust
 
 ## Code Style & Conventions
 
@@ -285,6 +309,16 @@ clojure -M:benchmark
 clojure -M:lint      # clj-kondo
 clojure -M:fmt       # Check formatting
 clojure -M:fmt-fix   # Fix formatting
+```
+
+### Export Tool
+
+```bash
+# Export bare repo to filesystem directory
+clojure -M:export /tmp/chrondb-export
+
+# Export with options
+clojure -M:export /tmp/chrondb-export --branch main --prefix users --format json
 ```
 
 ### Building
@@ -461,11 +495,16 @@ Each language binding (Python, Rust, etc.) **MUST** implement a robust wrapper l
 
 ### Implementing a New Binding
 
+**Preferred path**: Add to UniFFI UDL (`bindings/uniffi/src/chrondb.udl`) — generates
+Python, Ruby, Kotlin, Swift automatically from a single interface definition.
+
+**Alternative**: Use NAPI-RS (Node.js) or direct FFI for languages not supported by UniFFI.
+
 When creating a binding for a new language:
 
-1. **Start with lifecycle management** - ensure resources are always cleaned up
-2. **Implement shared isolate registry** - keyed by `(data_path, index_path)`
-3. **Add signal handlers** - graceful shutdown on SIGTERM/SIGINT
+1. **Add method to UDL** if using UniFFI, or implement directly against `chrondb` Rust crate
+2. **Implement language wrapper** — idiomatic API on top of generated FFI code
+3. **Start with lifecycle management** - ensure resources are always cleaned up
 4. **Wrap all FFI calls** - add timeouts, error translation, logging
 5. **Test crash scenarios** - kill -9, out of memory, disk full
 6. **Test concurrent access** - multiple processes, same database path
@@ -487,33 +526,67 @@ native-image @target/shared-image-args -H:Name=libchrondb
 ```python
 from chrondb import ChronDB
 
-with ChronDB(data_path="./data", index_path="./index") as db:
-    db.put("users/1", {"name": "Alice"})
-    user = db.get("users/1")
-    history = db.history("users/1")
+with ChronDB("/tmp/mydb") as db:
+    db.put("users:1", {"name": "Alice"})
+    user = db.get("users:1")
+    db.export_to_directory("/tmp/export", branch="main")
+    db.create_backup("/backups/full.tar.gz")
 ```
 
 Key implementation details:
-- Shared isolate registry: `_isolate_registry` keyed by paths
-- Reference counting: `add_ref()`, `release()`
-- Auto library discovery: `~/.chrondb/lib/` or `CHRONDB_LIB_PATH`
+- UniFFI-generated `_generated/chrondb.py` + hand-written `_wrapper.py`
+- Dict-based API (JSON serialization handled internally)
+- Context manager support
 
 ### Rust Bindings
 
 ```rust
 use chrondb::ChronDB;
 
-let db = ChronDB::open("./data", "./index")?;
-db.put("users/1", serde_json::json!({"name": "Alice"}))?;
-let user = db.get("users/1")?;
-let history = db.history("users/1")?;
+let db = ChronDB::open_path("./mydb")?;
+db.put("users:1", &json!({"name": "Alice"}), None)?;
+let user = db.get("users:1", None)?;
+db.export_to_directory("/tmp/export", None)?;
+db.create_backup("/backups/full.tar.gz", None)?;
 ```
 
 Key implementation details:
 - Shared worker registry: `OnceLock<Mutex<HashMap<...>>>`
 - 64MB stack for FFI worker thread
-- Command channel: Put, Get, Delete, Query, Shutdown
+- Command channel: Put, Get, Delete, Query, ExecuteSql, SetupRemote, Push, Pull, Fetch, Export, CreateBackup, RestoreBackup, ExportSnapshot, ImportSnapshot, Shutdown
 - Auto library download via `ensure_library_installed()`
+
+### Ruby Bindings
+
+```ruby
+db = ChronDB::Client.new("/tmp/mydb")
+db.put("users:1", { name: "Alice" })
+user = db.get("users:1")
+db.export_to_directory("/tmp/export")
+db.create_backup("/backups/full.tar.gz")
+```
+
+Key implementation details:
+- UniFFI-generated `chrondb_generated.rb` + hand-written `lib/chrondb.rb`
+- Hash-based API with keyword arguments
+- Exception hierarchy: `ChronDB::Error`, `ChronDB::DocumentNotFoundError`
+
+### Node.js Bindings
+
+```javascript
+const { ChronDB } = require('chrondb')
+
+const db = new ChronDB('/tmp/mydb')
+db.put('users:1', { name: 'Alice' })
+const user = db.get('users:1')
+db.exportToDirectory('/tmp/export')
+db.createBackup('/backups/full.tar.gz')
+```
+
+Key implementation details:
+- NAPI-RS compiled to native `.node` binary (not UniFFI)
+- TypeScript definitions in `index.d.ts`
+- camelCase API (JS convention)
 
 ### Testing Bindings
 
@@ -523,6 +596,12 @@ cd bindings/rust && cargo test
 
 # Python
 cd bindings/python && pytest
+
+# Ruby
+cd bindings/ruby && ruby test/test_chrondb.rb
+
+# Node.js
+cd bindings/node && node __test__/test.mjs
 ```
 
 ## Native Image Considerations
@@ -570,7 +649,8 @@ When modifying:
 - **Lucene/search**: Update `docs/architecture.md`, `docs/performance.md`
 - **API endpoints**: Update `docs/` and add examples
 - **Configuration**: Update `config.example.edn` and `docs/quickstart.md`
-- **Bindings**: Update `docs/bindings/python.md` or `docs/bindings/rust.md`
+- **Bindings**: Update `docs/bindings/{python,rust,ruby,nodejs}.md` and `docs/bindings/overview.md`
+- **Export tool**: Update `docs/operations.md`
 
 ## Resources
 

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -27,4 +27,28 @@ export class ChronDB {
   history(id: string, branch?: string | null): Record<string, unknown>[];
   query(query: Record<string, unknown>, branch?: string | null): Record<string, unknown>;
   execute(sql: string, branch?: string | null): SqlResult;
+
+  exportToDirectory(targetDir: string, options?: {
+    branch?: string;
+    prefix?: string;
+    format?: 'json' | 'raw';
+    decodePaths?: boolean;
+    overwrite?: boolean;
+  }): Record<string, unknown>;
+
+  createBackup(outputPath: string, options?: {
+    format?: 'tar.gz' | 'bundle';
+    verify?: boolean;
+  }): Record<string, unknown>;
+
+  restoreBackup(inputPath: string, options?: {
+    format?: 'tar.gz' | 'bundle';
+    verify?: boolean;
+  }): Record<string, unknown>;
+
+  exportSnapshot(outputPath: string, options?: {
+    refs?: string[];
+  }): Record<string, unknown>;
+
+  importSnapshot(inputPath: string): Record<string, unknown>;
 }

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -129,7 +129,6 @@ class ChronDB {
     const result = this._inner.executeSql(sql, branch)
     return JSON.parse(result)
   }
-}
 
   /**
    * Export the repository tree to a filesystem directory.

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -131,4 +131,75 @@ class ChronDB {
   }
 }
 
+  /**
+   * Export the repository tree to a filesystem directory.
+   * @param {string} targetDir - Target directory path
+   * @param {Object} [options]
+   * @param {string} [options.branch] - Branch to export
+   * @param {string} [options.prefix] - Only export paths matching prefix
+   * @param {string} [options.format] - "json" (pretty, default) or "raw"
+   * @param {boolean} [options.decodePaths] - Decode encoded paths (default: true)
+   * @param {boolean} [options.overwrite] - Overwrite existing target (default: false)
+   * @returns {Object} Export metadata
+   */
+  exportToDirectory(targetDir, options = {}) {
+    const opts = {}
+    if (options.branch) opts.branch = options.branch
+    if (options.prefix) opts.prefix = options.prefix
+    if (options.format) opts.format = options.format
+    if (options.decodePaths !== undefined) opts.decode_paths = options.decodePaths
+    if (options.overwrite !== undefined) opts.overwrite = options.overwrite
+    const result = this._inner.exportToDirectory(targetDir, JSON.stringify(opts))
+    return JSON.parse(result)
+  }
+
+  /**
+   * Create a full backup of the repository.
+   * @param {string} outputPath - Backup file path
+   * @param {Object} [options]
+   * @param {string} [options.format] - "tar.gz" (default) or "bundle"
+   * @param {boolean} [options.verify] - Run integrity checks (default: true)
+   * @returns {Object} Backup metadata
+   */
+  createBackup(outputPath, options = {}) {
+    const result = this._inner.createBackup(outputPath, JSON.stringify(options))
+    return JSON.parse(result)
+  }
+
+  /**
+   * Restore the repository from a backup file.
+   * @param {string} inputPath - Backup file path
+   * @param {Object} [options]
+   * @param {string} [options.format] - "tar.gz" (default) or "bundle"
+   * @param {boolean} [options.verify] - Run integrity checks (default: true)
+   * @returns {Object} Restore metadata
+   */
+  restoreBackup(inputPath, options = {}) {
+    const result = this._inner.restoreBackup(inputPath, JSON.stringify(options))
+    return JSON.parse(result)
+  }
+
+  /**
+   * Export the repository to a git bundle snapshot.
+   * @param {string} outputPath - Bundle file path
+   * @param {Object} [options]
+   * @param {string[]} [options.refs] - Refs to include
+   * @returns {Object} Snapshot metadata
+   */
+  exportSnapshot(outputPath, options = {}) {
+    const result = this._inner.exportSnapshot(outputPath, JSON.stringify(options))
+    return JSON.parse(result)
+  }
+
+  /**
+   * Import a git bundle snapshot into the repository.
+   * @param {string} inputPath - Bundle file path
+   * @returns {Object} Import metadata
+   */
+  importSnapshot(inputPath) {
+    const result = this._inner.importSnapshot(inputPath, '{}')
+    return JSON.parse(result)
+  }
+}
+
 module.exports = { ChronDB }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -112,6 +112,76 @@ impl ChronDB {
         serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
+    /// Exports the repository tree to a filesystem directory.
+    #[napi]
+    pub fn export_to_directory(
+        &self,
+        target_dir: String,
+        options_json: Option<String>,
+    ) -> Result<String> {
+        let result = self
+            .inner
+            .export_to_directory(&target_dir, options_json.as_deref())
+            .map_err(to_napi_error)?;
+        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Creates a full backup of the repository.
+    #[napi]
+    pub fn create_backup(
+        &self,
+        output_path: String,
+        options_json: Option<String>,
+    ) -> Result<String> {
+        let result = self
+            .inner
+            .create_backup(&output_path, options_json.as_deref())
+            .map_err(to_napi_error)?;
+        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Restores the repository from a backup file.
+    #[napi]
+    pub fn restore_backup(
+        &self,
+        input_path: String,
+        options_json: Option<String>,
+    ) -> Result<String> {
+        let result = self
+            .inner
+            .restore_backup(&input_path, options_json.as_deref())
+            .map_err(to_napi_error)?;
+        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Exports the repository to a git bundle snapshot.
+    #[napi]
+    pub fn export_snapshot(
+        &self,
+        output_path: String,
+        options_json: Option<String>,
+    ) -> Result<String> {
+        let result = self
+            .inner
+            .export_snapshot(&output_path, options_json.as_deref())
+            .map_err(to_napi_error)?;
+        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Imports a git bundle snapshot into the repository.
+    #[napi]
+    pub fn import_snapshot(
+        &self,
+        input_path: String,
+        options_json: Option<String>,
+    ) -> Result<String> {
+        let result = self
+            .inner
+            .import_snapshot(&input_path, options_json.as_deref())
+            .map_err(to_napi_error)?;
+        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
     /// Returns the last error message from the native library.
     #[napi]
     pub fn last_error(&self) -> Option<String> {

--- a/bindings/python/chrondb/_wrapper.py
+++ b/bindings/python/chrondb/_wrapper.py
@@ -196,3 +196,128 @@ class ChronDB:
             return json.loads(result)
         except _ffi.ChronDbError as e:
             raise _convert_error(e) from e
+
+    # --- Export & Backup ---
+
+    def export_to_directory(self, target_dir: str,
+                            branch: Optional[str] = None,
+                            prefix: Optional[str] = None,
+                            format: str = "json",
+                            decode_paths: bool = True,
+                            overwrite: bool = False) -> Dict[str, Any]:
+        """Export the repository tree to a filesystem directory.
+
+        Args:
+            target_dir: Target directory path.
+            branch: Branch to export (default: main).
+            prefix: Only export paths matching this prefix.
+            format: "json" (pretty-printed, default) or "raw".
+            decode_paths: Decode encoded paths (default: True).
+            overwrite: Overwrite existing target directory (default: False).
+
+        Returns:
+            Export metadata dict with status, files_exported, etc.
+        """
+        try:
+            opts: Dict[str, Any] = {}
+            if branch:
+                opts["branch"] = branch
+            if prefix:
+                opts["prefix"] = prefix
+            if format != "json":
+                opts["format"] = format
+            if not decode_paths:
+                opts["decode_paths"] = False
+            if overwrite:
+                opts["overwrite"] = True
+            result = self._inner.export_to_directory(
+                target_dir, json.dumps(opts) if opts else None)
+            return json.loads(result)
+        except _ffi.ChronDbError as e:
+            raise _convert_error(e) from e
+
+    def create_backup(self, output_path: str,
+                      format: str = "tar.gz",
+                      verify: bool = True) -> Dict[str, Any]:
+        """Create a full backup of the repository.
+
+        Args:
+            output_path: Backup file path.
+            format: "tar.gz" (default) or "bundle".
+            verify: Run integrity checks (default: True).
+
+        Returns:
+            Backup metadata dict with status, path, checksum.
+        """
+        try:
+            opts: Dict[str, Any] = {}
+            if format != "tar.gz":
+                opts["format"] = format
+            if not verify:
+                opts["verify"] = False
+            result = self._inner.create_backup(
+                output_path, json.dumps(opts) if opts else None)
+            return json.loads(result)
+        except _ffi.ChronDbError as e:
+            raise _convert_error(e) from e
+
+    def restore_backup(self, input_path: str,
+                       format: str = "tar.gz",
+                       verify: bool = True) -> Dict[str, Any]:
+        """Restore the repository from a backup file.
+
+        Args:
+            input_path: Backup file path.
+            format: "tar.gz" (default) or "bundle".
+            verify: Run integrity checks (default: True).
+
+        Returns:
+            Restore metadata dict with status, restore_type.
+        """
+        try:
+            opts: Dict[str, Any] = {}
+            if format != "tar.gz":
+                opts["format"] = format
+            if not verify:
+                opts["verify"] = False
+            result = self._inner.restore_backup(
+                input_path, json.dumps(opts) if opts else None)
+            return json.loads(result)
+        except _ffi.ChronDbError as e:
+            raise _convert_error(e) from e
+
+    def export_snapshot(self, output_path: str,
+                        refs: Optional[list] = None) -> Dict[str, Any]:
+        """Export the repository to a git bundle snapshot.
+
+        Args:
+            output_path: Bundle file path.
+            refs: Optional list of refs to include.
+
+        Returns:
+            Snapshot metadata dict.
+        """
+        try:
+            opts: Dict[str, Any] = {}
+            if refs:
+                opts["refs"] = refs
+            result = self._inner.export_snapshot(
+                output_path, json.dumps(opts) if opts else None)
+            return json.loads(result)
+        except _ffi.ChronDbError as e:
+            raise _convert_error(e) from e
+
+    def import_snapshot(self, input_path: str) -> Dict[str, Any]:
+        """Import a git bundle snapshot into the repository.
+
+        Args:
+            input_path: Bundle file path.
+
+        Returns:
+            Import metadata dict.
+        """
+        try:
+            result = self._inner.import_snapshot(input_path, None)
+            return json.loads(result)
+        except _ffi.ChronDbError as e:
+            raise _convert_error(e) from e

--- a/bindings/ruby/lib/chrondb.rb
+++ b/bindings/ruby/lib/chrondb.rb
@@ -149,5 +149,85 @@ module ChronDB
     rescue Chrondb::ChronDbError => e
       raise Error, e.message
     end
+
+    # Export the repository tree to a filesystem directory.
+    #
+    # @param target_dir [String] Target directory path
+    # @param branch [String, nil] Branch to export
+    # @param prefix [String, nil] Only export paths matching prefix
+    # @param format [String] "json" (default) or "raw"
+    # @param decode_paths [Boolean] Decode encoded paths (default: true)
+    # @param overwrite [Boolean] Overwrite existing target (default: false)
+    # @return [Hash] Export metadata
+    def export_to_directory(target_dir, branch: nil, prefix: nil, format: "json",
+                            decode_paths: true, overwrite: false)
+      opts = {}
+      opts[:branch] = branch if branch
+      opts[:prefix] = prefix if prefix
+      opts[:format] = format if format != "json"
+      opts[:decode_paths] = false unless decode_paths
+      opts[:overwrite] = true if overwrite
+      result = @inner.export_to_directory(target_dir, opts.empty? ? nil : JSON.generate(opts))
+      JSON.parse(result)
+    rescue Chrondb::ChronDbError => e
+      raise Error, e.message
+    end
+
+    # Create a full backup of the repository.
+    #
+    # @param output_path [String] Backup file path
+    # @param format [String] "tar.gz" (default) or "bundle"
+    # @param verify [Boolean] Run integrity checks (default: true)
+    # @return [Hash] Backup metadata
+    def create_backup(output_path, format: "tar.gz", verify: true)
+      opts = {}
+      opts[:format] = format if format != "tar.gz"
+      opts[:verify] = false unless verify
+      result = @inner.create_backup(output_path, opts.empty? ? nil : JSON.generate(opts))
+      JSON.parse(result)
+    rescue Chrondb::ChronDbError => e
+      raise Error, e.message
+    end
+
+    # Restore the repository from a backup file.
+    #
+    # @param input_path [String] Backup file path
+    # @param format [String] "tar.gz" (default) or "bundle"
+    # @param verify [Boolean] Run integrity checks (default: true)
+    # @return [Hash] Restore metadata
+    def restore_backup(input_path, format: "tar.gz", verify: true)
+      opts = {}
+      opts[:format] = format if format != "tar.gz"
+      opts[:verify] = false unless verify
+      result = @inner.restore_backup(input_path, opts.empty? ? nil : JSON.generate(opts))
+      JSON.parse(result)
+    rescue Chrondb::ChronDbError => e
+      raise Error, e.message
+    end
+
+    # Export the repository to a git bundle snapshot.
+    #
+    # @param output_path [String] Bundle file path
+    # @param refs [Array<String>, nil] Refs to include
+    # @return [Hash] Snapshot metadata
+    def export_snapshot(output_path, refs: nil)
+      opts = {}
+      opts[:refs] = refs if refs
+      result = @inner.export_snapshot(output_path, opts.empty? ? nil : JSON.generate(opts))
+      JSON.parse(result)
+    rescue Chrondb::ChronDbError => e
+      raise Error, e.message
+    end
+
+    # Import a git bundle snapshot into the repository.
+    #
+    # @param input_path [String] Bundle file path
+    # @return [Hash] Import metadata
+    def import_snapshot(input_path)
+      result = @inner.import_snapshot(input_path, nil)
+      JSON.parse(result)
+    rescue Chrondb::ChronDbError => e
+      raise Error, e.message
+    end
   end
 end

--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -136,6 +136,41 @@ type ChrondbRemoteStatusFn = unsafe extern "C" fn(
     handle: c_int,
 ) -> *mut c_char;
 
+type ChrondbExportFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+    target_dir: *const c_char,
+    options_json: *const c_char,
+) -> *mut c_char;
+
+type ChrondbCreateBackupFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+    output_path: *const c_char,
+    options_json: *const c_char,
+) -> *mut c_char;
+
+type ChrondbRestoreBackupFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+    input_path: *const c_char,
+    options_json: *const c_char,
+) -> *mut c_char;
+
+type ChrondbExportSnapshotFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+    output_path: *const c_char,
+    options_json: *const c_char,
+) -> *mut c_char;
+
+type ChrondbImportSnapshotFn = unsafe extern "C" fn(
+    thread: *mut graal_isolatethread_t,
+    handle: c_int,
+    input_path: *const c_char,
+    options_json: *const c_char,
+) -> *mut c_char;
+
 /// Holds the dynamically loaded library and function pointers.
 pub struct ChronDBLib {
     #[allow(dead_code)]
@@ -160,6 +195,11 @@ pub struct ChronDBLib {
     pub chrondb_pull: ChrondbPullFn,
     pub chrondb_fetch: ChrondbFetchFn,
     pub chrondb_remote_status: ChrondbRemoteStatusFn,
+    pub chrondb_export: ChrondbExportFn,
+    pub chrondb_create_backup: ChrondbCreateBackupFn,
+    pub chrondb_restore_backup: ChrondbRestoreBackupFn,
+    pub chrondb_export_snapshot: ChrondbExportSnapshotFn,
+    pub chrondb_import_snapshot: ChrondbImportSnapshotFn,
 }
 
 // Safety: The library handle and function pointers are safe to share across threads
@@ -304,6 +344,26 @@ impl ChronDBLib {
                 .get::<ChrondbRemoteStatusFn>(b"chrondb_remote_status")
                 .map_err(|e| format!("Symbol chrondb_remote_status not found: {}", e))?;
 
+            let chrondb_export: ChrondbExportFn = *lib
+                .get::<ChrondbExportFn>(b"chrondb_export")
+                .map_err(|e| format!("Symbol chrondb_export not found: {}", e))?;
+
+            let chrondb_create_backup: ChrondbCreateBackupFn = *lib
+                .get::<ChrondbCreateBackupFn>(b"chrondb_create_backup")
+                .map_err(|e| format!("Symbol chrondb_create_backup not found: {}", e))?;
+
+            let chrondb_restore_backup: ChrondbRestoreBackupFn = *lib
+                .get::<ChrondbRestoreBackupFn>(b"chrondb_restore_backup")
+                .map_err(|e| format!("Symbol chrondb_restore_backup not found: {}", e))?;
+
+            let chrondb_export_snapshot: ChrondbExportSnapshotFn = *lib
+                .get::<ChrondbExportSnapshotFn>(b"chrondb_export_snapshot")
+                .map_err(|e| format!("Symbol chrondb_export_snapshot not found: {}", e))?;
+
+            let chrondb_import_snapshot: ChrondbImportSnapshotFn = *lib
+                .get::<ChrondbImportSnapshotFn>(b"chrondb_import_snapshot")
+                .map_err(|e| format!("Symbol chrondb_import_snapshot not found: {}", e))?;
+
             Ok(ChronDBLib {
                 lib,
                 graal_create_isolate,
@@ -326,6 +386,11 @@ impl ChronDBLib {
                 chrondb_pull,
                 chrondb_fetch,
                 chrondb_remote_status,
+                chrondb_export,
+                chrondb_create_backup,
+                chrondb_restore_backup,
+                chrondb_export_snapshot,
+                chrondb_import_snapshot,
             })
         }
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -118,6 +118,31 @@ enum FfiCommand {
     RemoteStatus {
         reply: Sender<Result<serde_json::Value>>,
     },
+    Export {
+        target_dir: String,
+        options: String,
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    CreateBackup {
+        output_path: String,
+        options: String,
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    RestoreBackup {
+        input_path: String,
+        options: String,
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    ExportSnapshot {
+        output_path: String,
+        options: String,
+        reply: Sender<Result<serde_json::Value>>,
+    },
+    ImportSnapshot {
+        input_path: String,
+        options: String,
+        reply: Sender<Result<serde_json::Value>>,
+    },
     Shutdown,
 }
 
@@ -398,6 +423,76 @@ impl FfiWorkerState {
         if result.is_null() {
             return Err(self.last_error_or("remote_status failed"));
         }
+        self.parse_string_result(result)
+    }
+
+    fn handle_export(&self, target_dir: &str, options: &str) -> Result<serde_json::Value> {
+        let c_dir = CString::new(target_dir).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let c_opts = CString::new(options).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let result = unsafe {
+            (self.lib.chrondb_export)(
+                self.thread, self.handle,
+                c_dir.as_ptr() as *mut c_char,
+                c_opts.as_ptr() as *mut c_char,
+            )
+        };
+        if result.is_null() { return Err(self.last_error_or("export failed")); }
+        self.parse_string_result(result)
+    }
+
+    fn handle_create_backup(&self, output_path: &str, options: &str) -> Result<serde_json::Value> {
+        let c_path = CString::new(output_path).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let c_opts = CString::new(options).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let result = unsafe {
+            (self.lib.chrondb_create_backup)(
+                self.thread, self.handle,
+                c_path.as_ptr() as *mut c_char,
+                c_opts.as_ptr() as *mut c_char,
+            )
+        };
+        if result.is_null() { return Err(self.last_error_or("create_backup failed")); }
+        self.parse_string_result(result)
+    }
+
+    fn handle_restore_backup(&self, input_path: &str, options: &str) -> Result<serde_json::Value> {
+        let c_path = CString::new(input_path).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let c_opts = CString::new(options).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let result = unsafe {
+            (self.lib.chrondb_restore_backup)(
+                self.thread, self.handle,
+                c_path.as_ptr() as *mut c_char,
+                c_opts.as_ptr() as *mut c_char,
+            )
+        };
+        if result.is_null() { return Err(self.last_error_or("restore_backup failed")); }
+        self.parse_string_result(result)
+    }
+
+    fn handle_export_snapshot(&self, output_path: &str, options: &str) -> Result<serde_json::Value> {
+        let c_path = CString::new(output_path).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let c_opts = CString::new(options).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let result = unsafe {
+            (self.lib.chrondb_export_snapshot)(
+                self.thread, self.handle,
+                c_path.as_ptr() as *mut c_char,
+                c_opts.as_ptr() as *mut c_char,
+            )
+        };
+        if result.is_null() { return Err(self.last_error_or("export_snapshot failed")); }
+        self.parse_string_result(result)
+    }
+
+    fn handle_import_snapshot(&self, input_path: &str, options: &str) -> Result<serde_json::Value> {
+        let c_path = CString::new(input_path).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let c_opts = CString::new(options).map_err(|e| ChronDBError::OperationFailed(e.to_string()))?;
+        let result = unsafe {
+            (self.lib.chrondb_import_snapshot)(
+                self.thread, self.handle,
+                c_path.as_ptr() as *mut c_char,
+                c_opts.as_ptr() as *mut c_char,
+            )
+        };
+        if result.is_null() { return Err(self.last_error_or("import_snapshot failed")); }
         self.parse_string_result(result)
     }
 
@@ -754,6 +849,26 @@ impl ChronDB {
                 let result = state.handle_remote_status();
                 let _ = reply.send(result);
             }
+            FfiCommand::Export { target_dir, options, reply } => {
+                let result = state.handle_export(&target_dir, &options);
+                let _ = reply.send(result);
+            }
+            FfiCommand::CreateBackup { output_path, options, reply } => {
+                let result = state.handle_create_backup(&output_path, &options);
+                let _ = reply.send(result);
+            }
+            FfiCommand::RestoreBackup { input_path, options, reply } => {
+                let result = state.handle_restore_backup(&input_path, &options);
+                let _ = reply.send(result);
+            }
+            FfiCommand::ExportSnapshot { output_path, options, reply } => {
+                let result = state.handle_export_snapshot(&output_path, &options);
+                let _ = reply.send(result);
+            }
+            FfiCommand::ImportSnapshot { input_path, options, reply } => {
+                let result = state.handle_import_snapshot(&input_path, &options);
+                let _ = reply.send(result);
+            }
             FfiCommand::Shutdown => return true,
         }
         false
@@ -858,6 +973,11 @@ impl ChronDB {
             FfiCommand::Pull { reply, .. } => { let _ = reply.send(Err(err)); }
             FfiCommand::Fetch { reply, .. } => { let _ = reply.send(Err(err)); }
             FfiCommand::RemoteStatus { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::Export { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::CreateBackup { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::RestoreBackup { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::ExportSnapshot { reply, .. } => { let _ = reply.send(Err(err)); }
+            FfiCommand::ImportSnapshot { reply, .. } => { let _ = reply.send(Err(err)); }
             FfiCommand::Shutdown => {}
         }
     }
@@ -1120,6 +1240,106 @@ impl ChronDB {
 
         reply_rx
             .recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Exports the repository tree to a filesystem directory.
+    ///
+    /// Returns a JSON value with export metadata including file count.
+    pub fn export_to_directory(
+        &self,
+        target_dir: &str,
+        options_json: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.shared.sender
+            .send(FfiCommand::Export {
+                target_dir: target_dir.to_string(),
+                options: options_json.unwrap_or("{}").to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+        reply_rx.recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Creates a full backup of the repository.
+    ///
+    /// Returns a JSON value with backup metadata (path, checksum).
+    pub fn create_backup(
+        &self,
+        output_path: &str,
+        options_json: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.shared.sender
+            .send(FfiCommand::CreateBackup {
+                output_path: output_path.to_string(),
+                options: options_json.unwrap_or("{}").to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+        reply_rx.recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Restores the repository from a backup file.
+    ///
+    /// Returns a JSON value with restore metadata.
+    pub fn restore_backup(
+        &self,
+        input_path: &str,
+        options_json: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.shared.sender
+            .send(FfiCommand::RestoreBackup {
+                input_path: input_path.to_string(),
+                options: options_json.unwrap_or("{}").to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+        reply_rx.recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Exports the repository to a git bundle snapshot.
+    ///
+    /// Returns a JSON value with snapshot metadata.
+    pub fn export_snapshot(
+        &self,
+        output_path: &str,
+        options_json: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.shared.sender
+            .send(FfiCommand::ExportSnapshot {
+                output_path: output_path.to_string(),
+                options: options_json.unwrap_or("{}").to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+        reply_rx.recv()
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
+    }
+
+    /// Imports a git bundle snapshot into the repository.
+    ///
+    /// Returns a JSON value with import metadata.
+    pub fn import_snapshot(
+        &self,
+        input_path: &str,
+        options_json: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.shared.sender
+            .send(FfiCommand::ImportSnapshot {
+                input_path: input_path.to_string(),
+                options: options_json.unwrap_or("{}").to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?;
+        reply_rx.recv()
             .map_err(|_| ChronDBError::OperationFailed("worker thread died".to_string()))?
     }
 

--- a/bindings/uniffi/src/chrondb.udl
+++ b/bindings/uniffi/src/chrondb.udl
@@ -60,5 +60,20 @@ interface ChronDB {
     [Throws=ChronDBError]
     string remote_status();
 
+    [Throws=ChronDBError]
+    string export_to_directory(string target_dir, string? options_json);
+
+    [Throws=ChronDBError]
+    string create_backup(string output_path, string? options_json);
+
+    [Throws=ChronDBError]
+    string restore_backup(string input_path, string? options_json);
+
+    [Throws=ChronDBError]
+    string export_snapshot(string output_path, string? options_json);
+
+    [Throws=ChronDBError]
+    string import_snapshot(string input_path, string? options_json);
+
     string? last_error();
 };

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -180,6 +180,71 @@ impl ChronDB {
         })
     }
 
+    fn export_to_directory(
+        &self,
+        target_dir: String,
+        options_json: Option<String>,
+    ) -> Result<String, ChronDBError> {
+        let result = self
+            .inner
+            .export_to_directory(&target_dir, options_json.as_deref())?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn create_backup(
+        &self,
+        output_path: String,
+        options_json: Option<String>,
+    ) -> Result<String, ChronDBError> {
+        let result = self
+            .inner
+            .create_backup(&output_path, options_json.as_deref())?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn restore_backup(
+        &self,
+        input_path: String,
+        options_json: Option<String>,
+    ) -> Result<String, ChronDBError> {
+        let result = self
+            .inner
+            .restore_backup(&input_path, options_json.as_deref())?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn export_snapshot(
+        &self,
+        output_path: String,
+        options_json: Option<String>,
+    ) -> Result<String, ChronDBError> {
+        let result = self
+            .inner
+            .export_snapshot(&output_path, options_json.as_deref())?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
+    fn import_snapshot(
+        &self,
+        input_path: String,
+        options_json: Option<String>,
+    ) -> Result<String, ChronDBError> {
+        let result = self
+            .inner
+            .import_snapshot(&input_path, options_json.as_deref())?;
+        serde_json::to_string(&result).map_err(|e| ChronDBError::JsonError {
+            msg: e.to_string(),
+        })
+    }
+
     fn last_error(&self) -> Option<String> {
         self.inner.last_error()
     }

--- a/deps.edn
+++ b/deps.edn
@@ -145,5 +145,15 @@
                    :main-opts ["-m" "cljfmt.main" "check" "src" "test"]}
              :fmt-fix {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.12.0"}}
                        :main-opts ["-m" "cljfmt.main" "fix" "src" "test"]}
+             :export {:main-opts ["-m" "chrondb.tools.export"]
+                      :doc "Export bare repository tree to filesystem directory.
+                            Usage: clojure -M:export <target-dir> [options]
+                            Options:
+                              --branch BRANCH   Branch to export (default: main)
+                              --commit HASH     Specific commit to export
+                              --prefix PREFIX   Only export paths matching prefix
+                              --format FORMAT   json (pretty, default) or raw
+                              --overwrite       Overwrite existing target directory
+                              --no-decode       Don't decode encoded paths"}
              :codox {:extra-deps {codox/codox {:mvn/version "0.10.8"}}
                      :main-opts ["-m" "chrondb.docs"]}}}

--- a/docs/bindings/nodejs.md
+++ b/docs/bindings/nodejs.md
@@ -232,3 +232,40 @@ db.put('config:app', { version: '2.0' })
 const entries = db.history('config:app')
 entries.forEach(entry => console.log(entry))
 ```
+
+## Export & Backup
+
+### Export to Directory
+
+```javascript
+// Export current state to filesystem
+const result = db.exportToDirectory('/tmp/export')
+console.log(`Exported ${result.files_exported} files`)
+
+// Export with options
+const result = db.exportToDirectory('/tmp/export', {
+  branch: 'main',
+  prefix: 'users',
+  format: 'json',
+  decodePaths: true,
+  overwrite: true
+})
+```
+
+### Backup & Restore
+
+```javascript
+// Create a full backup
+const result = db.createBackup('/backups/full.tar.gz')
+console.log(`Backup at: ${result.path}`)
+
+// Create a bundle backup
+const result = db.createBackup('/backups/full.bundle', { format: 'bundle' })
+
+// Restore from backup
+const result = db.restoreBackup('/backups/full.tar.gz')
+
+// Export/import git bundle snapshots
+const result = db.exportSnapshot('/backups/main.bundle')
+const result = db.importSnapshot('/backups/main.bundle')
+```

--- a/docs/bindings/nodejs.md
+++ b/docs/bindings/nodejs.md
@@ -256,16 +256,16 @@ const result = db.exportToDirectory('/tmp/export', {
 
 ```javascript
 // Create a full backup
-const result = db.createBackup('/backups/full.tar.gz')
+let result = db.createBackup('/backups/full.tar.gz')
 console.log(`Backup at: ${result.path}`)
 
 // Create a bundle backup
-const result = db.createBackup('/backups/full.bundle', { format: 'bundle' })
+result = db.createBackup('/backups/full.bundle', { format: 'bundle' })
 
 // Restore from backup
-const result = db.restoreBackup('/backups/full.tar.gz')
+result = db.restoreBackup('/backups/full.tar.gz')
 
 // Export/import git bundle snapshots
-const result = db.exportSnapshot('/backups/main.bundle')
-const result = db.importSnapshot('/backups/main.bundle')
+result = db.exportSnapshot('/backups/main.bundle')
+result = db.importSnapshot('/backups/main.bundle')
 ```

--- a/docs/bindings/python.md
+++ b/docs/bindings/python.md
@@ -439,6 +439,45 @@ def test_put_and_get(db):
     assert doc["value"] == 42
 ```
 
+## Export & Backup
+
+### Export to Directory
+
+```python
+# Export current state to filesystem
+result = db.export_to_directory("/tmp/export")
+print(f"Exported {result['files_exported']} files")
+
+# Export specific branch with prefix filter
+result = db.export_to_directory(
+    "/tmp/export",
+    branch="feature-x",
+    prefix="users",
+    format="json",        # "json" (pretty) or "raw"
+    decode_paths=True,    # decode encoded paths
+    overwrite=True        # overwrite existing directory
+)
+```
+
+### Backup & Restore
+
+```python
+# Create a full backup
+result = db.create_backup("/backups/full.tar.gz")
+print(f"Backup at: {result['path']}")
+
+# Create a bundle backup
+result = db.create_backup("/backups/full.bundle", format="bundle")
+
+# Restore from backup
+result = db.restore_backup("/backups/full.tar.gz")
+print(f"Restore type: {result['restore_type']}")
+
+# Export/import git bundle snapshots
+result = db.export_snapshot("/backups/main.bundle")
+result = db.import_snapshot("/backups/main.bundle")
+```
+
 ## Building from Source
 
 ```bash

--- a/docs/bindings/ruby.md
+++ b/docs/bindings/ruby.md
@@ -215,3 +215,41 @@ db.put("config:app", { version: "2.0" })
 entries = db.history("config:app")
 entries.each { |entry| puts entry }
 ```
+
+## Export & Backup
+
+### Export to Directory
+
+```ruby
+# Export current state to filesystem
+result = db.export_to_directory("/tmp/export")
+puts "Exported #{result['files_exported']} files"
+
+# Export with options
+result = db.export_to_directory(
+  "/tmp/export",
+  branch: "main",
+  prefix: "users",
+  format: "json",
+  decode_paths: true,
+  overwrite: true
+)
+```
+
+### Backup & Restore
+
+```ruby
+# Create a full backup
+result = db.create_backup("/backups/full.tar.gz")
+puts "Backup at: #{result['path']}"
+
+# Create a bundle backup
+result = db.create_backup("/backups/full.bundle", format: "bundle")
+
+# Restore from backup
+result = db.restore_backup("/backups/full.tar.gz")
+
+# Export/import git bundle snapshots
+result = db.export_snapshot("/backups/main.bundle")
+result = db.import_snapshot("/backups/main.bundle")
+```

--- a/docs/bindings/rust.md
+++ b/docs/bindings/rust.md
@@ -593,6 +593,45 @@ fn main() -> chrondb::Result<()> {
 - Short-lived CLI tools (just use `ChronDB::open`)
 - High-throughput services with constant database access (the isolate would never go idle)
 
+## Export & Backup
+
+### Export to Directory
+
+```rust
+// Export current state to filesystem
+let result = db.export_to_directory("/tmp/export", None)?;
+println!("Exported {} files", result["files_exported"]);
+
+// Export with options
+let opts = serde_json::json!({
+    "branch": "main",
+    "prefix": "users",
+    "format": "json",
+    "decode_paths": true,
+    "overwrite": true
+});
+let result = db.export_to_directory("/tmp/export", Some(&opts.to_string()))?;
+```
+
+### Backup & Restore
+
+```rust
+// Create a full backup
+let result = db.create_backup("/backups/full.tar.gz", None)?;
+println!("Backup at: {}", result["path"]);
+
+// Create a bundle backup
+let opts = r#"{"format":"bundle"}"#;
+let result = db.create_backup("/backups/full.bundle", Some(opts))?;
+
+// Restore from backup
+let result = db.restore_backup("/backups/full.tar.gz", None)?;
+
+// Export/import git bundle snapshots
+let result = db.export_snapshot("/backups/main.bundle", None)?;
+let result = db.import_snapshot("/backups/main.bundle", None)?;
+```
+
 ## Building from Source
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -244,3 +244,19 @@ java -jar chrondb.jar --command remove-branch --name test-branch
 ### Disk Space Monitoring
 
 ChronDB will grow over time due to the historical storage nature. Monitor disk usage and configure retention policies if necessary.
+
+## FFI / Language Bindings
+
+Export and backup operations are available in all language bindings (Python, Rust, Ruby, Node.js).
+
+### Available Methods
+
+| Operation | Python | Rust | Ruby | Node.js |
+|-----------|--------|------|------|---------|
+| Export to directory | `export_to_directory()` | `export_to_directory()` | `export_to_directory()` | `exportToDirectory()` |
+| Create backup | `create_backup()` | `create_backup()` | `create_backup()` | `createBackup()` |
+| Restore backup | `restore_backup()` | `restore_backup()` | `restore_backup()` | `restoreBackup()` |
+| Export snapshot | `export_snapshot()` | `export_snapshot()` | `export_snapshot()` | `exportSnapshot()` |
+| Import snapshot | `import_snapshot()` | `import_snapshot()` | `import_snapshot()` | `importSnapshot()` |
+
+See the individual [binding documentation](bindings/overview.md) for detailed usage examples.

--- a/java/chrondb/lib/ChronDBLib.java
+++ b/java/chrondb/lib/ChronDBLib.java
@@ -37,6 +37,11 @@ public final class ChronDBLib {
     private static IFn libPull;
     private static IFn libFetch;
     private static IFn libRemoteStatus;
+    private static IFn libExport;
+    private static IFn libCreateBackup;
+    private static IFn libRestoreBackup;
+    private static IFn libExportSnapshot;
+    private static IFn libImportSnapshot;
 
     private static synchronized void ensureInitialized() {
         if (!initialized) {
@@ -59,6 +64,11 @@ public final class ChronDBLib {
             libPull = Clojure.var("chrondb.lib.core", "lib-pull");
             libFetch = Clojure.var("chrondb.lib.core", "lib-fetch");
             libRemoteStatus = Clojure.var("chrondb.lib.core", "lib-remote-status");
+            libExport = Clojure.var("chrondb.lib.core", "lib-export");
+            libCreateBackup = Clojure.var("chrondb.lib.core", "lib-create-backup");
+            libRestoreBackup = Clojure.var("chrondb.lib.core", "lib-restore-backup");
+            libExportSnapshot = Clojure.var("chrondb.lib.core", "lib-export-snapshot");
+            libImportSnapshot = Clojure.var("chrondb.lib.core", "lib-import-snapshot");
 
             initialized = true;
         }
@@ -373,6 +383,103 @@ public final class ChronDBLib {
                 return toCString((String) result);
             }
             lastError = ("remote_status returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    // --- Export & Backup ---
+
+    @CEntryPoint(name = "chrondb_export")
+    public static CCharPointer export(IsolateThread thread, int handle,
+                                      CCharPointer targetDir, CCharPointer optionsJson) {
+        try {
+            ensureInitialized();
+            String dir = toJavaString(targetDir);
+            String opts = toJavaString(optionsJson);
+            Object result = libExport.invoke(handle, dir, opts);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("export returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_create_backup")
+    public static CCharPointer createBackup(IsolateThread thread, int handle,
+                                            CCharPointer outputPath, CCharPointer optionsJson) {
+        try {
+            ensureInitialized();
+            String path = toJavaString(outputPath);
+            String opts = toJavaString(optionsJson);
+            Object result = libCreateBackup.invoke(handle, path, opts);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("create_backup returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_restore_backup")
+    public static CCharPointer restoreBackup(IsolateThread thread, int handle,
+                                             CCharPointer inputPath, CCharPointer optionsJson) {
+        try {
+            ensureInitialized();
+            String path = toJavaString(inputPath);
+            String opts = toJavaString(optionsJson);
+            Object result = libRestoreBackup.invoke(handle, path, opts);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("restore_backup returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_export_snapshot")
+    public static CCharPointer exportSnapshot(IsolateThread thread, int handle,
+                                              CCharPointer outputPath, CCharPointer optionsJson) {
+        try {
+            ensureInitialized();
+            String path = toJavaString(outputPath);
+            String opts = toJavaString(optionsJson);
+            Object result = libExportSnapshot.invoke(handle, path, opts);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("export_snapshot returned null");
+            return WordFactory.nullPointer();
+        } catch (Exception e) {
+            lastError = (e.getMessage());
+            return WordFactory.nullPointer();
+        }
+    }
+
+    @CEntryPoint(name = "chrondb_import_snapshot")
+    public static CCharPointer importSnapshot(IsolateThread thread, int handle,
+                                              CCharPointer inputPath, CCharPointer optionsJson) {
+        try {
+            ensureInitialized();
+            String path = toJavaString(inputPath);
+            String opts = toJavaString(optionsJson);
+            Object result = libImportSnapshot.invoke(handle, path, opts);
+            if (result instanceof String) {
+                return toCString((String) result);
+            }
+            lastError = ("import_snapshot returned null");
             return WordFactory.nullPointer();
         } catch (Exception e) {
             lastError = (e.getMessage());

--- a/src/chrondb/lib/core.clj
+++ b/src/chrondb/lib/core.clj
@@ -16,7 +16,8 @@
             [chrondb.util.logging :as log]
             [chrondb.util.locks :as locks]
             [clojure.data.json :as json]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clojure.string :as str])
   (:import [java.util.concurrent.atomic AtomicInteger]
            [org.eclipse.jgit.api Git]))
 
@@ -257,6 +258,29 @@
   [db-path]
   (lib-open db-path (derive-index-path db-path)))
 
+;; Lazy-load backup/export functions once, not on every call.
+(defonce ^:private backup-fns
+  (delay
+    (require 'chrondb.backup.core
+             'chrondb.tools.export)
+    {:create-backup   (ns-resolve 'chrondb.backup.core 'create-full-backup)
+     :restore-backup  (ns-resolve 'chrondb.backup.core 'restore-backup)
+     :export-snapshot (ns-resolve 'chrondb.backup.core 'export-snapshot)
+     :import-snapshot (ns-resolve 'chrondb.backup.core 'import-snapshot)
+     :export-dir      (ns-resolve 'chrondb.tools.export 'export-to-directory)}))
+
+(defn- parse-options
+  "Parses a JSON options string into a Clojure map with keyword keys.
+   Converts snake_case keys to kebab-case keywords.
+   Returns empty map if input is nil or empty."
+  [options-json]
+  (if (and options-json (not (.isEmpty ^String options-json)))
+    (let [raw (json/read-str options-json)
+          convert-key (fn [k]
+                        (keyword (str/replace k "_" "-")))]
+      (into {} (map (fn [[k v]] [(convert-key k) v]) raw)))
+    {}))
+
 ;; Lazy-load SQL engine functions once, not on every call.
 (defonce ^:private sql-fns
   (delay
@@ -496,3 +520,97 @@
     (catch Throwable e
       (json/write-str {:type "error"
                        :message (.getMessage e)}))))
+
+;; --- Export & Backup Operations ---
+
+(defn lib-export
+  "Exports the repository tree to a filesystem directory.
+   Options JSON keys: branch, commit, prefix, format (json|raw),
+   decode_paths (bool), overwrite (bool).
+   Returns JSON string with export result or nil on error."
+  [handle target-dir options-json]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [opts (parse-options options-json)
+            opts (cond-> opts
+                   (:format opts) (update :format keyword)
+                   (contains? opts :overwrite) (-> (assoc :overwrite? (:overwrite opts))
+                                                   (dissoc :overwrite))
+                   (contains? opts :decode-paths) (-> (assoc :decode-paths? (:decode-paths opts))
+                                                      (dissoc :decode-paths)))
+            result ((:export-dir @backup-fns) storage target-dir opts)]
+        (json/write-str result)))
+    (catch Throwable e
+      (json/write-str {:type "error" :message (.getMessage e)}))))
+
+(defn lib-create-backup
+  "Creates a full backup of the repository.
+   Options JSON keys: format (tar.gz|bundle), verify (bool), compress (bool).
+   Returns JSON string with backup result or nil on error."
+  [handle output-path options-json]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [opts (parse-options options-json)
+            opts (cond-> opts
+                   (:format opts) (update :format keyword)
+                   (contains? opts :verify) (-> (assoc :verify? (:verify opts))
+                                                (dissoc :verify))
+                   (contains? opts :compress) (-> (assoc :compress? (:compress opts))
+                                                  (dissoc :compress)))
+            result ((:create-backup @backup-fns) storage
+                                                 (assoc opts :output-path output-path))]
+        (json/write-str result)))
+    (catch Throwable e
+      (json/write-str {:type "error" :message (.getMessage e)}))))
+
+(defn lib-restore-backup
+  "Restores the repository from a backup file.
+   Options JSON keys: format (tar.gz|bundle), verify (bool).
+   Returns JSON string with restore result or nil on error."
+  [handle input-path options-json]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [opts (parse-options options-json)
+            opts (cond-> opts
+                   (:format opts) (update :format keyword)
+                   (contains? opts :verify) (-> (assoc :verify? (:verify opts))
+                                                (dissoc :verify)))
+            result ((:restore-backup @backup-fns) storage
+                                                  (assoc opts :input-path input-path))]
+        (json/write-str result)))
+    (catch Throwable e
+      (json/write-str {:type "error" :message (.getMessage e)}))))
+
+(defn lib-export-snapshot
+  "Exports the repository to a git bundle snapshot.
+   Options JSON keys: refs (array of strings), verify (bool).
+   Returns JSON string with snapshot result or nil on error."
+  [handle output-path options-json]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [opts (parse-options options-json)
+            opts (cond-> opts
+                   (contains? opts :verify) (-> (assoc :verify? (:verify opts))
+                                                (dissoc :verify)))
+            result ((:export-snapshot @backup-fns) storage
+                                                   (assoc opts :output output-path))]
+        (json/write-str result)))
+    (catch Throwable e
+      (json/write-str {:type "error" :message (.getMessage e)}))))
+
+(defn lib-import-snapshot
+  "Imports a git bundle snapshot into the repository.
+   Options JSON keys: verify (bool).
+   Returns JSON string with import result or nil on error."
+  [handle input-path options-json]
+  (try
+    (when-let [{:keys [storage]} (get @handle-registry handle)]
+      (let [opts (parse-options options-json)
+            opts (cond-> opts
+                   (contains? opts :verify) (-> (assoc :verify? (:verify opts))
+                                                (dissoc :verify)))
+            result ((:import-snapshot @backup-fns) storage
+                                                   (assoc opts :input input-path))]
+        (json/write-str result)))
+    (catch Throwable e
+      (json/write-str {:type "error" :message (.getMessage e)}))))

--- a/src/chrondb/tools/export.clj
+++ b/src/chrondb/tools/export.clj
@@ -1,0 +1,191 @@
+(ns chrondb.tools.export
+  "Export bare repository tree to filesystem directory.
+   Materializes Git blobs as regular files, preserving the
+   table-name/document-id.json directory structure."
+  (:require [chrondb.config :as config]
+            [chrondb.storage.git.core :as git-core]
+            [chrondb.storage.git.path :as path]
+            [chrondb.util.logging :as log]
+            [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import [java.io ByteArrayInputStream]
+           [java.time Instant]
+           [org.eclipse.jgit.lib Repository]
+           [org.eclipse.jgit.revwalk RevWalk]
+           [org.eclipse.jgit.treewalk TreeWalk]
+           [org.eclipse.jgit.treewalk.filter PathSuffixFilter]))
+
+(defn- resolve-commit
+  "Resolves the commit ObjectId from either an explicit commit hash or a branch HEAD."
+  [^Repository repo branch commit]
+  (if commit
+    (.resolve repo (str commit "^{commit}"))
+    (.resolve repo (str branch "^{commit}"))))
+
+(defn- decode-export-path
+  "Decodes an encoded Git path back to a human-readable form.
+   Splits path into segments and decodes each one."
+  [git-path]
+  (let [segments (str/split git-path #"/")]
+    (str/join "/" (map path/decode-path segments))))
+
+(defn- pretty-json-bytes
+  "Parses JSON content and re-serializes with indentation.
+   Falls back to raw content if parsing fails."
+  [^bytes content-bytes]
+  (let [raw (String. content-bytes "UTF-8")]
+    (try
+      (let [data (json/read-str raw)]
+        (.getBytes (json/write-str data :indent true) "UTF-8"))
+      (catch Exception _
+        content-bytes))))
+
+(defn- write-manifest
+  "Writes export metadata manifest to .chrondb-export.json in the target directory."
+  [target-dir {:keys [branch commit files-exported]}]
+  (let [manifest {:exported-at (str (Instant/now))
+                  :branch branch
+                  :commit (str commit)
+                  :files-exported files-exported
+                  :format "chrondb-export-v1"}
+        manifest-file (io/file target-dir ".chrondb-export.json")]
+    (spit manifest-file (json/write-str manifest :indent true))))
+
+(defn- validate-target-dir
+  "Validates the target directory. Creates it if needed.
+   Fails if non-empty and overwrite? is false."
+  [target-dir overwrite?]
+  (let [dir (io/file target-dir)]
+    (when (.exists dir)
+      (when (and (not overwrite?)
+                 (.isDirectory dir)
+                 (pos? (count (.listFiles dir))))
+        (throw (ex-info "Target directory is not empty. Use :overwrite? true to overwrite."
+                        {:target-dir target-dir}))))
+    (.mkdirs dir)))
+
+(defn export-to-directory
+  "Exports the current state of a branch to a filesystem directory.
+   Materializes all Git blobs as regular files, preserving the
+   table-name/document-id.json directory structure.
+
+   Options:
+   - :branch        branch to export (default: configured default-branch)
+   - :commit        specific commit hash (overrides branch HEAD)
+   - :prefix        only export documents matching this path prefix
+   - :decode-paths? decode encoded paths back to original form (default: true)
+   - :overwrite?    overwrite existing files in target directory (default: false)
+   - :format        :json (pretty-printed, default) or :raw (as stored)
+
+   Returns:
+   {:status :ok
+    :files-exported  count
+    :target-dir      string
+    :branch          string
+    :commit          string
+    :timestamp       string}"
+  ([storage target-dir]
+   (export-to-directory storage target-dir {}))
+  ([storage target-dir {:keys [branch commit prefix decode-paths? overwrite? format]
+                        :or {decode-paths? true overwrite? false format :json}}]
+   (let [repo (:repository storage)
+         _ (when-not repo
+             (throw (ex-info "Storage repository is closed" {})))
+         config-map (config/load-config)
+         branch-name (or branch (get-in config-map [:git :default-branch]))
+         commit-id (resolve-commit repo branch-name commit)
+         _ (when-not commit-id
+             (throw (ex-info "Could not resolve commit"
+                             {:branch branch-name :commit commit})))
+         encoded-prefix (when prefix (path/encode-path prefix))]
+     (validate-target-dir target-dir overwrite?)
+     (let [rev-walk (RevWalk. repo)
+           commit-obj (.parseCommit rev-walk commit-id)
+           tree (.getTree commit-obj)
+           tree-walk (TreeWalk. repo)]
+       (try
+         (.addTree tree-walk tree)
+         (.setRecursive tree-walk true)
+         (.setFilter tree-walk (PathSuffixFilter/create ".json"))
+         (loop [count 0]
+           (if (.next tree-walk)
+             (let [git-path (.getPathString tree-walk)]
+               (if (and encoded-prefix
+                        (not (.startsWith git-path (str encoded-prefix "/")))
+                        (not (.startsWith git-path (str encoded-prefix "."))))
+                 (recur count)
+                 (let [object-id (.getObjectId tree-walk 0)
+                       loader (.open repo object-id)
+                       content-bytes (.getBytes loader)
+                       dest-path (if decode-paths?
+                                   (decode-export-path git-path)
+                                   git-path)
+                       dest-file (io/file target-dir dest-path)]
+                   (.mkdirs (.getParentFile dest-file))
+                   (let [output-bytes (if (= format :json)
+                                        (pretty-json-bytes content-bytes)
+                                        content-bytes)]
+                     (io/copy (ByteArrayInputStream. output-bytes) dest-file))
+                   (when (zero? (mod (inc count) 100))
+                     (log/log-info (str "Exported " (inc count) " files...")))
+                   (recur (inc count)))))
+             (let [result {:status :ok
+                           :files-exported count
+                           :target-dir (str target-dir)
+                           :branch branch-name
+                           :commit (.getName commit-id)
+                           :timestamp (str (Instant/now))}]
+               (when (pos? count)
+                 (write-manifest target-dir result))
+               (log/log-info (str "Export complete: " count " files to " target-dir))
+               result)))
+         (finally
+           (.close tree-walk)
+           (.close rev-walk)))))))
+
+(defn -main
+  "CLI entry point for the export tool.
+
+   Usage: clojure -M:export <target-dir> [options]
+
+   Options:
+     --branch BRANCH     Branch to export (default: main)
+     --commit HASH       Specific commit to export
+     --prefix PREFIX     Only export paths matching prefix
+     --format FORMAT     json (pretty, default) or raw
+     --overwrite         Overwrite existing target directory
+     --no-decode         Don't decode encoded paths"
+  [& args]
+  (let [config-map (config/load-config)
+        repository-dir (or (get-in config-map [:storage :repository-dir]) "data")
+        data-dir (get-in config-map [:storage :data-dir])
+        ;; Parse args
+        {:keys [target-dir options]}
+        (loop [remaining args
+               target nil
+               opts {}]
+          (if (empty? remaining)
+            {:target-dir target :options opts}
+            (let [[arg & rest-args] remaining]
+              (case arg
+                "--branch" (recur (rest rest-args) target (assoc opts :branch (first rest-args)))
+                "--commit" (recur (rest rest-args) target (assoc opts :commit (first rest-args)))
+                "--prefix" (recur (rest rest-args) target (assoc opts :prefix (first rest-args)))
+                "--format" (recur (rest rest-args) target (assoc opts :format (keyword (first rest-args))))
+                "--overwrite" (recur rest-args target (assoc opts :overwrite? true))
+                "--no-decode" (recur rest-args target (assoc opts :decode-paths? false))
+                (recur rest-args (or target arg) opts)))))]
+    (when-not target-dir
+      (println "Usage: clojure -M:export <target-dir> [--branch BRANCH] [--commit HASH] [--prefix PREFIX] [--format json|raw] [--overwrite] [--no-decode]")
+      (System/exit 1))
+    (let [storage (git-core/open-git-storage repository-dir data-dir)]
+      (try
+        (let [result (export-to-directory storage target-dir options)]
+          (println (json/write-str result :indent true)))
+        (catch Exception e
+          (binding [*out* *err*]
+            (println (str "Export failed: " (.getMessage e))))
+          (System/exit 1))
+        (finally
+          (.close (:repository storage)))))))

--- a/src/chrondb/tools/export.clj
+++ b/src/chrondb/tools/export.clj
@@ -25,10 +25,22 @@
 
 (defn- decode-export-path
   "Decodes an encoded Git path back to a human-readable form.
-   Splits path into segments and decodes each one."
+   Splits path into segments, decodes each one, and rejects
+   unsafe paths that could escape the export target directory."
   [git-path]
-  (let [segments (str/split git-path #"/")]
-    (str/join "/" (map path/decode-path segments))))
+  (let [segments (str/split git-path #"/")
+        decoded (mapv (fn [segment]
+                        (let [d (path/decode-path segment)]
+                          (when (or (= ".." d)
+                                    (str/starts-with? d "/")
+                                    (str/starts-with? d "\\")
+                                    (re-matches #"^[A-Za-z]:.*" d))
+                            (throw (ex-info "Unsafe export path detected"
+                                            {:git-path git-path
+                                             :decoded-segment d})))
+                          d))
+                      segments)]
+    (str/join "/" decoded)))
 
 (defn- pretty-json-bytes
   "Parses JSON content and re-serializes with indentation.
@@ -54,16 +66,23 @@
 
 (defn- validate-target-dir
   "Validates the target directory. Creates it if needed.
-   Fails if non-empty and overwrite? is false."
+   Fails if path exists but is not a directory, or if non-empty without overwrite."
   [target-dir overwrite?]
   (let [dir (io/file target-dir)]
-    (when (.exists dir)
-      (when (and (not overwrite?)
-                 (.isDirectory dir)
-                 (pos? (count (.listFiles dir))))
-        (throw (ex-info "Target directory is not empty. Use :overwrite? true to overwrite."
-                        {:target-dir target-dir}))))
-    (.mkdirs dir)))
+    (if (.exists dir)
+      (do
+        (when-not (.isDirectory dir)
+          (throw (ex-info "Target path exists but is not a directory."
+                          {:target-dir target-dir})))
+        (let [files (.listFiles dir)]
+          (when (and (not overwrite?)
+                     files
+                     (pos? (count files)))
+            (throw (ex-info "Target directory is not empty. Use :overwrite? true to overwrite."
+                            {:target-dir target-dir})))))
+      (when-not (.mkdirs dir)
+        (throw (ex-info "Failed to create target directory."
+                        {:target-dir target-dir}))))))
 
 (defn export-to-directory
   "Exports the current state of a branch to a filesystem directory.

--- a/test/chrondb/tools/export_test.clj
+++ b/test/chrondb/tools/export_test.clj
@@ -1,0 +1,251 @@
+(ns chrondb.tools.export-test
+  (:require [chrondb.config :as config]
+            [chrondb.storage.git.core :as git-core]
+            [chrondb.storage.protocol :as protocol]
+            [chrondb.tools.export :as export]
+            [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing use-fixtures]])
+  (:import [java.io File]))
+
+(def test-repo-path "test-export-repo")
+(def test-export-path "test-export-output")
+
+(def test-config
+  {:git {:default-branch "main"
+         :committer-name "Test User"
+         :committer-email "test@example.com"
+         :push-enabled false}
+   :storage {:data-dir nil}
+   :logging {:level :info}})
+
+(defn delete-directory [^File directory]
+  (when (.exists directory)
+    (doseq [file (reverse (file-seq directory))]
+      (.delete file))))
+
+(defn clean-test-dirs [f]
+  (delete-directory (io/file test-repo-path))
+  (delete-directory (io/file test-export-path))
+  (with-redefs [config/load-config (constantly test-config)]
+    (try
+      (f)
+      (finally
+        (delete-directory (io/file test-repo-path))
+        (delete-directory (io/file test-export-path))))))
+
+(use-fixtures :each clean-test-dirs)
+
+(defn- create-storage []
+  (git-core/create-git-storage test-repo-path nil))
+
+(defn- save-doc [storage id data]
+  (protocol/save-document storage (assoc data :id id)))
+
+(defn- exported-json-files
+  "Returns all .json files in the export dir, excluding the manifest."
+  [export-dir]
+  (->> (file-seq (io/file export-dir))
+       (filter #(.isFile %))
+       (filter #(.endsWith (.getName %) ".json"))
+       (remove #(= ".chrondb-export.json" (.getName %)))))
+
+(deftest test-export-empty-repository
+  (testing "Exporting an empty repository produces zero files"
+    (let [storage (create-storage)]
+      (try
+        (let [result (export/export-to-directory storage test-export-path)]
+          (is (= :ok (:status result)))
+          (is (= 0 (:files-exported result)))
+          (is (= "main" (:branch result))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-single-document
+  (testing "Exporting a single document creates the correct file"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice" :age 30})
+        (let [result (export/export-to-directory storage test-export-path)]
+          (is (= :ok (:status result)))
+          (is (= 1 (:files-exported result)))
+          (let [files (exported-json-files test-export-path)]
+            (is (= 1 (count files)))
+            (let [content (json/read-str (slurp (first files)) :key-fn keyword)]
+              (is (= "Alice" (:name content)))
+              (is (= 30 (:age content))))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-multiple-documents
+  (testing "Exporting multiple documents across tables"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (save-doc storage "users:2" {:name "Bob"})
+        (save-doc storage "orders:100" {:item "Widget" :qty 5})
+        (let [result (export/export-to-directory storage test-export-path)]
+          (is (= :ok (:status result)))
+          (is (= 3 (:files-exported result)))
+          ;; Verify manifest
+          (let [manifest-file (io/file test-export-path ".chrondb-export.json")]
+            (is (.exists manifest-file))
+            (let [manifest (json/read-str (slurp manifest-file) :key-fn keyword)]
+              (is (= 3 (:files-exported manifest)))
+              (is (= "main" (:branch manifest)))
+              (is (= "chrondb-export-v1" (:format manifest))))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-with-prefix-filter
+  (testing "Prefix filter only exports matching documents"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (save-doc storage "users:2" {:name "Bob"})
+        (save-doc storage "orders:100" {:item "Widget"})
+        (let [result (export/export-to-directory storage test-export-path
+                                                 {:prefix "users"})]
+          (is (= :ok (:status result)))
+          (is (= 2 (:files-exported result))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-raw-format
+  (testing "Raw format exports blob content as-is without re-formatting"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (let [result (export/export-to-directory storage test-export-path
+                                                 {:format :raw})]
+          (is (= :ok (:status result)))
+          (is (= 1 (:files-exported result)))
+          ;; Raw format should produce valid JSON (whatever the blob contains)
+          (let [files (exported-json-files test-export-path)]
+            (is (some? (json/read-str (slurp (first files)))))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-json-format-is-indented
+  (testing "JSON format exports pretty-printed content"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (let [result (export/export-to-directory storage test-export-path
+                                                 {:format :json})]
+          (is (= :ok (:status result)))
+          (let [files (exported-json-files test-export-path)
+                content (slurp (first files))]
+            ;; Pretty-printed JSON has newlines
+            (is (.contains content "\n"))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-no-decode-paths
+  (testing "With decode-paths? false, encoded paths are preserved on disk"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (let [result (export/export-to-directory storage test-export-path
+                                                 {:decode-paths? false})]
+          (is (= :ok (:status result)))
+          (is (= 1 (:files-exported result)))
+          ;; Encoded paths should have _COLON_ in directory or file names
+          (let [all-paths (->> (file-seq (io/file test-export-path))
+                               (map #(.getPath %)))]
+            (is (some #(.contains % "_COLON_") all-paths))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-decode-paths-default
+  (testing "Default export decodes encoded paths"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (let [result (export/export-to-directory storage test-export-path)]
+          (is (= :ok (:status result)))
+          (is (= 1 (:files-exported result)))
+          ;; Decoded paths should NOT have _COLON_
+          (let [all-paths (->> (file-seq (io/file test-export-path))
+                               (map #(.getPath %)))]
+            (is (not (some #(.contains % "_COLON_") all-paths)))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-overwrite-protection
+  (testing "Fails when target directory is non-empty without overwrite flag"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        ;; First export
+        (export/export-to-directory storage test-export-path)
+        ;; Second export should fail
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"not empty"
+                              (export/export-to-directory storage test-export-path)))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-overwrite-allowed
+  (testing "Succeeds when overwrite? is true"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        ;; First export
+        (export/export-to-directory storage test-export-path)
+        ;; Second export with overwrite should succeed
+        (let [result (export/export-to-directory storage test-export-path
+                                                 {:overwrite? true})]
+          (is (= :ok (:status result))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-specific-commit
+  (testing "Export a specific commit (time-travel)"
+    (let [storage (create-storage)]
+      (try
+        ;; Save first version
+        (save-doc storage "users:1" {:name "Alice" :version 1})
+        ;; Get commit after first save
+        (let [repo (:repository storage)
+              first-commit (.getName (.resolve repo "main^{commit}"))]
+          ;; Save second version (overwrites)
+          (save-doc storage "users:1" {:name "Alice Updated" :version 2})
+          ;; Export the first commit
+          (let [result (export/export-to-directory storage test-export-path
+                                                   {:commit first-commit})]
+            (is (= :ok (:status result)))
+            (is (= first-commit (:commit result)))
+            ;; Verify content is from first version
+            (let [files (exported-json-files test-export-path)
+                  content (json/read-str (slurp (first files)) :key-fn keyword)]
+              (is (= 1 (:version content))))))
+        (finally
+          (protocol/close storage))))))
+
+(deftest test-export-closed-storage
+  (testing "Throws when storage is closed"
+    (let [storage (create-storage)]
+      (protocol/close storage)
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"closed"
+                            (export/export-to-directory
+                             (assoc storage :repository nil)
+                             test-export-path))))))
+
+(deftest test-export-directory-structure
+  (testing "Export preserves table directory structure"
+    (let [storage (create-storage)]
+      (try
+        (save-doc storage "users:1" {:name "Alice"})
+        (save-doc storage "orders:100" {:item "Widget"})
+        (export/export-to-directory storage test-export-path)
+        ;; Should have subdirectories for each table
+        (let [subdirs (->> (.listFiles (io/file test-export-path))
+                           (filter #(.isDirectory %))
+                           (map #(.getName %))
+                           set)]
+          (is (contains? subdirs "users"))
+          (is (contains? subdirs "orders")))
+        (finally
+          (protocol/close storage))))))


### PR DESCRIPTION
ChronDB uses bare Git repos, so there's no working tree — users had no way to inspect the current database state as regular files on disk. Backup/restore was also only accessible from Clojure CLI, not from language bindings.

Added export-to-directory that walks the Git tree via JGit TreeWalk and materializes blobs as JSON files, with path decoding, prefix filtering, and time-travel support. Exposed both export and backup/restore (full, incremental, snapshot) through the full FFI stack: Clojure lib, Java CEntryPoint, Rust core, UniFFI, plus Python, Ruby, and Node.js wrappers with docs for all four languages.

Closes #139, closes #122